### PR TITLE
Fix multi-resource parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 const (
 	AnnotationKeyTimeout        = "uptest.upbound.io/timeout"
 	AnnotationKeyConditions     = "uptest.upbound.io/conditions"
@@ -18,6 +20,12 @@ type AutomatedTest struct {
 	DefaultConditions []string
 }
 
+type Manifest struct {
+	FilePath string
+	Object   *unstructured.Unstructured
+	YAML     string
+}
+
 type TestCase struct {
 	Timeout            int
 	SetupScriptPath    string
@@ -28,7 +36,7 @@ type Resource struct {
 	Name      string
 	Namespace string
 	KindGroup string
-	Manifest  string
+	YAML      string
 
 	Timeout              int
 	Conditions           []string

--- a/internal/templates/00-apply.yaml.tmpl
+++ b/internal/templates/00-apply.yaml.tmpl
@@ -6,5 +6,5 @@ commands:
 {{ end }}
 {{- range $resource := .Resources -}}
 ---
-{{ $resource.Manifest }}
+{{ $resource.YAML }}
 {{- end }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -1,10 +1,12 @@
 package templates
 
 import (
+	"testing"
+
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	
 	"github.com/upbound/uptest/internal/config"
-	"testing"
 )
 
 const (
@@ -51,7 +53,7 @@ func TestRender(t *testing.T) {
 					{
 						Name:       "example-bucket",
 						KindGroup:  "s3.aws.upbound.io",
-						Manifest:   bucketManifest,
+						YAML:       bucketManifest,
 						Conditions: []string{"Test"},
 					},
 				},
@@ -90,14 +92,14 @@ commands:
 				},
 				resources: []config.Resource{
 					{
-						Manifest:            bucketManifest,
+						YAML:                bucketManifest,
 						Name:                "example-bucket",
 						KindGroup:           "s3.aws.upbound.io",
 						PreAssertScriptPath: "/tmp/bucket/pre-assert.sh",
 						Conditions:          []string{"Test"},
 					},
 					{
-						Manifest:             claimManifest,
+						YAML:                 claimManifest,
 						Name:                 "test-cluster-claim",
 						KindGroup:            "cluster.gcp.platformref.upbound.io",
 						Namespace:            "upbound-system",


### PR DESCRIPTION
### Description of your changes

Fixes a regression introduced by #24 where only one of the resources parsed when there are multiple YAMLs in a given file.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Found this while testing latest changes with upbound/provider-aws. 
At the end tested with `make uptest-local MANIFEST_LIST=examples/s3/bucket.yaml` there.
