### PR TITLE
[Backport to release-0.1] option to pass test directory instead of using os.TmpDir

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,8 @@ func main() {
 			"Timeout could be overridden per resource using \"uptest.upbound.io/timeout\" annotation.").Default("1200").Int()
 		defaultConditions = e2e.Flag("default-conditions", "Comma seperated list of default conditions to wait for a successful test.\n"+
 			"Conditions could be overridden per resource using \"uptest.upbound.io/conditions\" annotation.").Default("Ready").String()
+
+		testDir = e2e.Flag("test-directory", "Directory where kuttl test case will be generated and executed.").Envar("UPTEST_TEST_DIR").Default(filepath.Join(os.TempDir(), "uptest-e2e")).String()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -72,6 +74,7 @@ func main() {
 		TeardownScriptPath: teardownPath,
 		DefaultConditions:  strings.Split(*defaultConditions, ","),
 		DefaultTimeout:     *defaultTimeout,
+		Directory:          *testDir,
 	}
 
 	kingpin.FatalIfError(internal.RunTest(o), "cannot run e2e tests successfully")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ const (
 )
 
 type AutomatedTest struct {
+	Directory string
+
 	ManifestPaths  []string
 	DataSourcePath string
 

--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -21,16 +21,15 @@ import (
 )
 
 var (
-	testDirectory = filepath.Join(os.TempDir(), "uptest-e2e")
-	caseDirectory = filepath.Join(testDirectory, "case")
-)
-
-var (
 	charset = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
 	dataSourceRegex = regexp.MustCompile("\\${data\\.(.*?)}")
 	randomStrRegex  = regexp.MustCompile("\\${Rand\\.(.*?)}")
+
+	caseDirectory = "case"
 )
+
+type PreparerOption func(*Preparer)
 
 func WithDataSource(path string) PreparerOption {
 	return func(p *Preparer) {
@@ -38,11 +37,16 @@ func WithDataSource(path string) PreparerOption {
 	}
 }
 
-type PreparerOption func(*Preparer)
+func WithTestDirectory(path string) PreparerOption {
+	return func(p *Preparer) {
+		p.testDirectory = path
+	}
+}
 
 func NewPreparer(testFilePaths []string, opts ...PreparerOption) *Preparer {
 	p := &Preparer{
 		testFilePaths: testFilePaths,
+		testDirectory: os.TempDir(),
 	}
 	for _, f := range opts {
 		f(p)
@@ -53,9 +57,11 @@ func NewPreparer(testFilePaths []string, opts ...PreparerOption) *Preparer {
 type Preparer struct {
 	testFilePaths  []string
 	dataSourcePath string
+	testDirectory  string
 }
 
 func (p *Preparer) PrepareManifests() ([]config.Manifest, error) {
+	caseDirectory := filepath.Join(p.testDirectory, caseDirectory)
 	if err := os.MkdirAll(caseDirectory, os.ModePerm); err != nil {
 		return nil, errors.Wrapf(err, "cannot create directory %s", caseDirectory)
 	}

--- a/internal/runner.go
+++ b/internal/runner.go
@@ -8,7 +8,7 @@ import (
 
 func RunTest(o *config.AutomatedTest) error {
 	// Read examples and inject data source values to manifests
-	manifests, err := NewPreparer(o.ManifestPaths, WithDataSource(o.DataSourcePath)).PrepareManifests()
+	manifests, err := NewPreparer(o.ManifestPaths, WithDataSource(o.DataSourcePath), WithTestDirectory(o.Directory)).PrepareManifests()
 	if err != nil {
 		return errors.Wrap(err, "cannot prepare manifests")
 	}

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -32,8 +32,8 @@ func (t *Tester) ExecuteTests() error {
 	if err := t.writeKuttlFiles(); err != nil {
 		return errors.Wrap(err, "cannot write kuttl test files")
 	}
-	fmt.Println("Running kuttl tests at " + testDirectory)
-	cmd := exec.Command("bash", "-c", fmt.Sprintf(`"${KUTTL}" test --start-kind=false --skip-cluster-delete %s --timeout %d 2>&1`, testDirectory, t.options.DefaultTimeout))
+	fmt.Println("Running kuttl tests at " + t.options.Directory)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(`"${KUTTL}" test --start-kind=false --skip-cluster-delete %s --timeout %d 2>&1`, t.options.Directory, t.options.DefaultTimeout))
 	stdout, _ := cmd.StdoutPipe()
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "cannot start kuttl")
@@ -119,7 +119,7 @@ func (t *Tester) writeKuttlFiles() error {
 	}
 
 	for k, v := range files {
-		if err := os.WriteFile(filepath.Join(caseDirectory, k), []byte(v), fs.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(filepath.Join(t.options.Directory, caseDirectory), k), []byte(v), fs.ModePerm); err != nil {
 			return errors.Wrapf(err, "cannot write file %q", k)
 		}
 	}


### PR DESCRIPTION
### Description of your changes

Backports #29 to release-0.1

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

See #29