### PR TITLE
Pass by reference in yaml marshall

### DIFF
--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -109,7 +109,7 @@ func (p *Preparer) injectVariables() (map[string]string, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot read data source file")
 		}
-		if err := yaml.Unmarshal(dataSource, dataSourceMap); err != nil {
+		if err := yaml.Unmarshal(dataSource, &dataSourceMap); err != nil {
 			return nil, errors.Wrap(err, "cannot prepare data source map")
 		}
 	}


### PR DESCRIPTION
### Description of your changes

Recently, I've introduced some changes removing dependency to `gopkg.in/yaml.v2` in favor of `sigs.k8s.io/yaml` to consistently use the same library for yaml processing instead of depending multiple.

This seems to break parameter injection from data source due to [this](https://github.com/kubernetes-sigs/yaml/issues/30) difference between yaml libraries.

This PR fixes this issue by passing reference of map.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Via debugging using goland.
