### PR TITLE
Add support for pre/post delete hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uptest e2e examples/user.yaml,examples/bucket.yaml --setup-script="test/hooks/se
 
 ### Hooks
 
-There are 4 types of hooks that can be used to customize the test flow:
+There are 6 types of hooks that can be used to customize the test flow:
 
 1. `setup-script`: This hook will be executed before running the tests case. It is useful to set up the control plane
    before running the tests. For example, you can use it to create a provider config and your cloud credentials. This
@@ -54,6 +54,10 @@ There are 4 types of hooks that can be used to customize the test flow:
     manifest file.
 4. `post-assert-hook`: This hook will be executed after running the assertions. This can be configured via 
     `uptest.upbound.io/post-assert-hook` annotation on the manifest as a relative path to the manifest file.
+5. `pre-delete-hook`: This hook will be executed just before deleting the resource. This can be configured via 
+    `uptest.upbound.io/pre-delete-hook` annotation on the manifest as a relative path to the manifest file.
+6. `post-delete-hook`: This hook will be executed right after the resource is deleted. This can be configured via
+   `uptest.upbound.io/post-delete-hook` annotation on the manifest as a relative path to the manifest file.
 
 > All hooks need to be executables, please make sure to set the executable bit on your scripts, e.g. with `chmod +x`.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ const (
 	AnnotationKeyConditions     = "uptest.upbound.io/conditions"
 	AnnotationKeyPreAssertHook  = "uptest.upbound.io/pre-assert-hook"
 	AnnotationKeyPostAssertHook = "uptest.upbound.io/post-assert-hook"
+	AnnotationKeyPreDeleteHook  = "uptest.upbound.io/pre-delete-hook"
+	AnnotationKeyPostDeleteHook = "uptest.upbound.io/post-delete-hook"
 )
 
 type AutomatedTest struct {
@@ -44,4 +46,6 @@ type Resource struct {
 	Conditions           []string
 	PreAssertScriptPath  string
 	PostAssertScriptPath string
+	PreDeleteScriptPath  string
+	PostDeleteScriptPath string
 }

--- a/internal/templates/01-delete.yaml.tmpl
+++ b/internal/templates/01-delete.yaml.tmpl
@@ -2,9 +2,15 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 {{- range $resource := .Resources }}
+{{- if $resource.PreDeleteScriptPath }}
+- command: {{ $resource.PreDeleteScriptPath }}
+{{- end }}
 {{- if $resource.Namespace }}
 - command: ${KUBECTL} delete {{ $resource.KindGroup }}/{{ $resource.Name }} --wait=false --namespace {{ $resource.Namespace }} --ignore-not-found
 {{- else }}
 - command: ${KUBECTL} delete {{ $resource.KindGroup }}/{{ $resource.Name }} --wait=false --ignore-not-found
+{{- end }}
+{{- if $resource.PostDeleteScriptPath }}
+- command: {{ $resource.PostDeleteScriptPath }}
 {{- end }}
 {{- end }}

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -101,6 +101,20 @@ func (t *Tester) prepareConfig() (*config.TestCase, []config.Resource, error) {
 			}
 		}
 
+		if v, ok := annotations[config.AnnotationKeyPreDeleteHook]; ok {
+			example.PreDeleteScriptPath, err = filepath.Abs(filepath.Join(filepath.Dir(m.FilePath), filepath.Clean(v)))
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "cannot find absolute path for pre delete hook")
+			}
+		}
+
+		if v, ok := annotations[config.AnnotationKeyPostDeleteHook]; ok {
+			example.PostDeleteScriptPath, err = filepath.Abs(filepath.Join(filepath.Dir(m.FilePath), filepath.Clean(v)))
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "cannot find absolute path for post delete hook")
+			}
+		}
+
 		examples = append(examples, example)
 	}
 


### PR DESCRIPTION
### Description of your changes

Adds support for pre/post delete hooks.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Unit tests.
