### PR TITLE
Handle secrets properly

### DIFF
--- a/internal/templates/00-assert.yaml.tmpl
+++ b/internal/templates/00-assert.yaml.tmpl
@@ -4,6 +4,9 @@ timeout: {{ .TestCase.Timeout }}
 commands:
 - command: ${KUBECTL} annotate managed --all upjet.upbound.io/test=true --overwrite
 {{- range $resource := .Resources }}
+{{- if eq $resource.KindGroup "secret." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.PreAssertScriptPath }}
 - command: {{ $resource.PreAssertScriptPath }}
 {{- end }}

--- a/internal/templates/01-assert.yaml.tmpl
+++ b/internal/templates/01-assert.yaml.tmpl
@@ -3,6 +3,9 @@ kind: TestAssert
 timeout: {{ .TestCase.Timeout }}
 commands:
 {{- range $resource := .Resources }}
+{{- if eq $resource.KindGroup "secret." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.Namespace }}
 - command: ${KUBECTL} wait {{ $resource.KindGroup }}/{{ $resource.Name }} --for=delete --timeout 10s --namespace {{ $resource.Namespace }}
 {{- else }}

--- a/internal/templates/01-delete.yaml.tmpl
+++ b/internal/templates/01-delete.yaml.tmpl
@@ -2,6 +2,9 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 {{- range $resource := .Resources }}
+{{- if eq $resource.KindGroup "secret." -}}
+  {{continue}}
+{{- end -}}
 {{- if $resource.PreDeleteScriptPath }}
 - command: {{ $resource.PreDeleteScriptPath }}
 {{- end }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -29,6 +29,16 @@ spec:
       count: 1
       size: small
 `
+
+	secretManifest = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: upbound-system
+type: Opaque
+data:
+  key: dmFsdWU=
+`
 )
 
 func TestRender(t *testing.T) {
@@ -108,6 +118,12 @@ commands:
 						PreDeleteScriptPath:  "/tmp/claim/pre-delete.sh",
 						Conditions:           []string{"Ready", "Synced"},
 					},
+					{
+						YAML:      secretManifest,
+						Name:      "test-secret",
+						KindGroup: "secret.",
+						Namespace: "upbound-system",
+					},
 				},
 			},
 			want: want{
@@ -116,7 +132,7 @@ commands:
 kind: TestStep
 commands:
 - command: /tmp/setup.sh
-` + "---\n" + bucketManifest + "---\n" + claimManifest,
+` + "---\n" + bucketManifest + "---\n" + claimManifest + "---\n" + secretManifest,
 					"00-assert.yaml": `apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 10

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -56,10 +56,6 @@ func (t *Tester) prepareConfig() (*config.TestCase, []config.Resource, error) {
 
 	for _, m := range t.manifests {
 		obj := m.Object
-		if obj.GroupVersionKind().String() == "/v1, Kind=Secret" {
-			continue
-		}
-
 		kg := strings.ToLower(obj.GroupVersionKind().Kind + "." + obj.GroupVersionKind().Group)
 
 		example := config.Resource{


### PR DESCRIPTION
### Description of your changes

@ytsarev identified a regression from the recent refactoring that we are not handling secrets as before.
This PR fixes that.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Unit tests and with https://github.com/upbound/platform-ref-gcp/pull/39