### PR TITLE
[release-0.2] Cherry pick fail if no manifest

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,8 +47,7 @@ func main() {
 		examplePaths = append(examplePaths, filepath.Join(cd, filepath.Clean(e)))
 	}
 	if len(examplePaths) == 0 {
-		fmt.Println("No example files to test.")
-		return
+		kingpin.Fatalf("No manifest to test provided.")
 	}
 
 	setupPath := ""


### PR DESCRIPTION
### Description of your changes

It causes a misleading impression as the tests are successful when no example manifest provided for whatever reason.
See https://github.com/upbound/upjet-provider-template/pull/15#issuecomment-1305716878 as an example.

Cherry picked from commit 44976727ff2297b4538429478a4d1fad845f3b45

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

N/A
