### PR TITLE
Fix datasource file step in e2e workflow

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -129,7 +129,7 @@ jobs:
           UPTEST_TEST_DIR: ./_output/controlplane-dump
           UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml
         run: |
-          mkdir -p .work && echo ${{ secrets.UPTEST_DATASOURCE }} > .work/uptest-datasource.yaml
+          mkdir -p .work && echo "${{ secrets.UPTEST_DATASOURCE }}" > .work/uptest-datasource.yaml
           make e2e
 
       - name: Create Successful Status Check


### PR DESCRIPTION
### Description of your changes

Currently it is failing with the following in https://github.com/upbound/provider-aws/pull/129

```
shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.19.2/x64
    UPTEST_CLOUD_CREDENTIALS: ***
    UPTEST_EXAMPLE_LIST: examples/iam/user.yaml,
    UPTEST_TEST_DIR: ./_output/controlplane-dump
    UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml
***
/home/runner/work/_temp/b3b[8](https://github.com/upbound/provider-aws/actions/runs/3419691649/jobs/5693533610#step:6:8)aba4-62[9](https://github.com/upbound/provider-aws/actions/runs/3419691649/jobs/5693533610#step:6:9)c-4b68-a390-f7e15225a136.sh: line 2: aws_region:: command not found
Error: Process completed with exit code [12](https://github.com/upbound/provider-aws/actions/runs/3419691649/jobs/5693533610#step:6:12)7.
```

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

To be tested with https://github.com/upbound/provider-aws/pull/129 after merging this.
