### PR TITLE
Mark UPTEST_DATASOURCE as optional in e2e workflow

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -19,7 +19,7 @@ on:
         required: true
       UPTEST_DATASOURCE:
         description: 'A set of key-value pairs to be injected into the uptest'
-        required: true
+        required: false
 
 jobs:
   debug:


### PR DESCRIPTION
### Description of your changes

`UPTEST_DATASOURCE` secret is not always needed e2e and should be marked as optional.
See [this](https://github.com/upbound/platform-ref-azure/pull/22#discussion_r1020277967) as an example.


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I locally tested passing `--data-source` flag both empty string and/or path to an empty file works fine with no side effect.