### PR TITLE
Add issue triage GitHub action

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,35 @@
+name: Issue Triage
+
+on:
+  workflow_call:
+    secrets:
+      UPBOUND_BOT_GITHUB_TOKEN:
+        description: 'A PAT with permissions that allow adding issues to a project'
+        required: true      
+
+jobs:
+  community_issue_triage:
+    if: ${{ (github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'MEMBER' &&
+      github.event.issue.author_association != 'COLLABORATOR' ) }}
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+    steps:
+      - name: Label as community issue
+        if: ${{ !contains(github.event.issue.labels.*.name, 'community') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["community"]
+            })
+      - name: Add issue to Extensions Community Support project
+        uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/upbound/projects/104/views/1
+          github-token: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
+          labeled: community

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,7 +28,7 @@ jobs:
               labels: ["community"]
             })
       - name: Add issue to Extensions Community Support project
-        uses: actions/add-to-project@RELEASE_VERSION
+        uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/upbound/projects/104/views/1
           github-token: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Jean du Plessis <jean@upbound.io>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Adds a shared GitHub workflow that repos can use to automatically label issues with the `community` label if the issue is opened by a user that is not part of the Upbound organization on GitHub. It will also add the issue to the Extensions Community Support project.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually tested on `jeanduplessis/provider-aws`