### PR TITLE
bugfix: linting errors - S1007 and SA1019

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
 	github.com/tufin/oasdiff v1.2.6
+	golang.org/x/mod v0.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/yuin/goldmark v1.5.3 // indirect
-	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -4,14 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,8 +23,8 @@ import (
 var (
 	charset = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
-	dataSourceRegex = regexp.MustCompile("\\${data\\.(.*?)}")
-	randomStrRegex  = regexp.MustCompile("\\${Rand\\.(.*?)}")
+	dataSourceRegex = regexp.MustCompile(`\${data\.(.*?)}`)
+	randomStrRegex  = regexp.MustCompile(`\${Rand\.(.*?)}`)
 
 	caseDirectory = "case"
 )
@@ -105,7 +105,7 @@ func (p *Preparer) PrepareManifests() ([]config.Manifest, error) {
 func (p *Preparer) injectVariables() (map[string]string, error) {
 	dataSourceMap := make(map[string]string)
 	if p.dataSourcePath != "" {
-		dataSource, err := ioutil.ReadFile(p.dataSourcePath)
+		dataSource, err := os.ReadFile(p.dataSourcePath)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot read data source file")
 		}
@@ -116,7 +116,7 @@ func (p *Preparer) injectVariables() (map[string]string, error) {
 
 	inputs := make(map[string]string, len(p.testFilePaths))
 	for _, f := range p.testFilePaths {
-		manifestData, err := ioutil.ReadFile(f)
+		manifestData, err := os.ReadFile(f)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot read %s", f)
 		}

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -3,17 +3,21 @@ package templates
 import _ "embed" // nolint:golint
 
 // inputFileTemplate is the template for the input file.
+//
 //go:embed 00-apply.yaml.tmpl
 var inputFileTemplate string
 
 // assertFileTemplate is the template for the assert file.
+//
 //go:embed 00-assert.yaml.tmpl
 var assertFileTemplate string
 
 // deleteFileTemplate is the template for the delete file.
+//
 //go:embed 01-delete.yaml.tmpl
 var deleteFileTemplate string
 
 // assertDeletedFileTemplate is the template for delete assert file.
+//
 //go:embed 01-assert.yaml.tmpl
 var assertDeletedFileTemplate string


### PR DESCRIPTION
This PR fixes two errors when doing `make reviewable` 
- S1007: should use raw string (\`...\`) with regexp.MustCompile to avoid having to escape twice
- SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.
