### PR TITLE
Add an optional UPTEST_CLOUD_CREDENTIALS_2 secret to on.workflow_call.secrets in uptest for cross-account testing

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -17,6 +17,9 @@ on:
       UPTEST_CLOUD_CREDENTIALS:
         description: 'Uptest cloud credentials to be passed to the uptest target as environment variable'
         required: true
+      UPTEST_CLOUD_CREDENTIALS_2:
+        description: 'Second Uptest cloud credentials for cross-account testing to be passed to the uptest target as an environment variable'
+        required: false
       UPTEST_DATASOURCE:
         description: 'A set of key-value pairs to be injected into the uptest'
         required: false
@@ -125,6 +128,7 @@ jobs:
         id: run-uptest
         env:
           UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
+          UPTEST_CLOUD_CREDENTIALS_2: ${{ secrets.UPTEST_CLOUD_CREDENTIALS_2 }}
           UPTEST_EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
           UPTEST_TEST_DIR: ./_output/controlplane-dump
           UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

We would like to be able to utilize two programmatic access entities (such as two AWS IAM users, or GCP service accounts) for testing certain "cross-account" resources in the providers. This PR proposes a new `on.workflow_call` optional secret so that if the caller workflow specifies this additional secret, the reusable uptest workflow will inject a corresponding env. variable. 

As indicated [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets), if the caller specifies an unknown secret for the called workflow, it results in an error and we still need to inject the secret's value into the uptest's environment. Also, I'm not aware of a technique where the caller directly specifies the called workflow job's environment.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Manually tested via https://github.com/upbound/provider-aws/pull/231