### PR TITLE
Add debug of the `github.event.issue.author_association` in the issue-triage job

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,6 +8,12 @@ on:
         required: true      
 
 jobs:
+  debug:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Debug
+        run: |
+          echo "github.event.issue.author_association: ${{ github.event.issue.author_association }}"
   community_issue_triage:
     if: ${{ (github.event.issue.author_association != 'OWNER' &&
       github.event.issue.author_association != 'MEMBER' &&
@@ -32,4 +38,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/upbound/projects/104/views/1
           github-token: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
-          labeled: community


### PR DESCRIPTION
Also removes the label requirement for adding an issue to the support project.

This fixes an issue where the project step didn't know that the issue had the community label added from the previous step.
