### PR TITLE
Add missing author association role in logic

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,6 +17,7 @@ jobs:
   community_issue_triage:
     if: ${{ (github.event.issue.author_association != 'OWNER' &&
       github.event.issue.author_association != 'MEMBER' &&
+      github.event.issue.author_association != 'CONTRIBUTOR' &&
       github.event.issue.author_association != 'COLLABORATOR' ) }}
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
This fixes the problem where some Upbound org members still have issues marked with the `community` label.
