### PR TITLE
crddiff: Treat field removal as a breaking API change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
 	github.com/tufin/oasdiff v1.2.6
+	golang.org/x/mod v0.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/yuin/goldmark v1.5.3 // indirect
-	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
This PR proposes a change in the `crddiff` tooling so that removing optional or required fields will be treated as breaking API changes.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Tested by making the following changes in provider-gcp:
- Made the following configuration change to rename an (optional) referencer field:
```diff
diff --git a/config/compute/config.go b/config/compute/config.go
index 1b1a349..4e9233e 100644
--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -37,8 +37,9 @@ func Configure(p *config.Provider) { //nolint: gocyclo
                        Extractor: common.PathSelfLinkExtractor,
                }
                r.References["backend.group"] = config.Reference{
-                       Type:      "InstanceGroupManager",
-                       Extractor: PathInstanceGroupExtractor,
+                       Type:         "InstanceGroupManager",
+                       Extractor:    PathInstanceGroupExtractor,
+                       RefFieldName: "RenamedGroupRef",
                }
        })
```
- This results in the optional `spec.forProvider.backend[].groupRef` to be renamed as `spec.forProvider.backend[].renamedGroupRef` (an optional field is removed and a new optional field is added).
- `crddiff` reports the following between the base and the revision CRDs:
```shell
Version "v1beta1":
- Schema changed
  - Properties changed
    - Modified property: spec
      - Properties changed
        - Modified property: forProvider
          - Properties changed
            - Modified property: backend
              - Items changed
                - Properties changed
                  - Deleted property: groupRef
```