### PR TITLE
Report tested example manifest instead of the file list hash if the file list contains a single file

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -67,7 +67,8 @@ jobs:
           for P in $PATHS; do EXAMPLE_LIST="${EXAMPLE_LIST},$(find $P -name *.yaml | tr '\n' ',')"; done
 
           sudo apt-get -y install coreutils
-          EXAMPLE_HASH=$(echo ${EXAMPLE_LIST} | md5sum | cut -f1 -d" ")
+          COUNT=$(echo ${EXAMPLE_LIST:1} | grep -o ".yaml" | wc -l)
+          if [ $COUNT -gt 1 ]; then EXAMPLE_HASH=$(echo ${EXAMPLE_LIST} | md5sum | cut -f1 -d" "); else EXAMPLE_HASH=$(echo ${EXAMPLE_LIST:1} | sed 's/.$//'); fi
 
           echo "Examples: ${EXAMPLE_LIST:1}"
           echo "Example Hash: ${EXAMPLE_HASH}"


### PR DESCRIPTION
### Description of your changes

Report tested example manifest instead of the file list hash if the file list contains a single file

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in the following branch https://github.com/sergenyalcin/official-provider-aws/pull/2
