### PR TITLE
Add native provider version bump reusable workflow

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -1,0 +1,80 @@
+name: Native Provider Version Bump
+
+on:
+  workflow_call:
+    inputs:
+      provider-source:
+        description: 'Provider namespace/name to check, e.g., hashicorp/aws'
+        required: true
+        type: string
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.19'
+        required: false
+        type: string
+    secrets:
+      TOKEN:
+        description: 'Github token to use'
+        required: true
+
+jobs:
+  bump-version-makefile:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-lint-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v3
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Bump native provider version in Makefile
+        id: bump-mk
+        run: |
+          sed -i -E "s/^(export[[:space:]]+TERRAFORM_PROVIDER_VERSION[[:space:]]*:=[[:space:]]*).+/\1$(curl -sL 'https://registry.terraform.io/v1/providers/${{ inputs.provider-source }}' | jq -r .version)/" Makefile
+          echo "bumped=$(git diff --name-only Makefile)" >> $GITHUB_OUTPUT
+          echo "version=$(curl -sL 'https://registry.terraform.io/v1/providers/${{ inputs.provider-source }}' | jq -r .version)" >> $GITHUB_OUTPUT
+
+      - name: Install goimports & run make generate
+        if: steps.bump-mk.outputs.bumped != ''
+        run: |
+          go install golang.org/x/tools/cmd/goimports
+          make generate
+
+      - name: New pull request
+        if: steps.bump-mk.outputs.bumped != ''
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Bump native provider to version ${{ steps.bump-mk.outputs.version }}
+          commit-message: Bump native provider to version ${{ steps.bump-mk.outputs.version }}
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          base: main
+          token: ${{ secrets.TOKEN }}
+          signoff: false
+          labels: |
+            automated


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a reusable workflow to check for the latest version of a Terraform provider and open a version bump PR if a newer version of it is found, in an upjet-based provider repository.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested in a fork repo. Some parts still need nesting after the PR is reviewed & merged.