### PR TITLE
Alternate pipeline steps per package type under test

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -13,6 +13,10 @@ on:
         default: '1.19'
         required: false
         type: string
+      package-type:
+        default: 'provider'
+        required: false
+        type: string
     secrets:
       UPTEST_CLOUD_CREDENTIALS:
         description: 'Uptest cloud credentials to be passed to the uptest target as environment variable'
@@ -123,10 +127,12 @@ jobs:
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
 
       - name: Find the Go Build Cache
+        if: ${{ inputs.package-type  == 'provider' }}
         id: go
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
+        if: ${{ inputs.package-type  == 'provider' }}
         uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -134,6 +140,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-uptest-
 
       - name: Cache Go Dependencies
+        if: ${{ inputs.package-type  == 'provider' }}
         uses: actions/cache@v3
         with:
           path: .work/pkg
@@ -141,6 +148,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
+        if: ${{ inputs.package-type  == 'provider' }}
         run: make vendor vendor.check
 
       - name: Run Uptest


### PR DESCRIPTION

<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
* Introduce new input for the pacakge type
* Execute golang related steps for Provider package type by default
* Intention is to skip them in situations like Configuration package type testing and not fail in cases like https://github.com/upbound/platform-ref-aws/issues/98
* Fixes #86
I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Will perform additional tests with my fork and platform-ref-aws
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
