### PR TITLE
Add check-examples job to reusable CI

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -338,3 +338,18 @@ jobs:
 
       - name: Publish Artifacts
         run: make publish BRANCH_NAME=${GITHUB_REF##*/}
+
+  check-examples:
+    runs-on: ubuntu-22.04
+    needs: detect-noop
+    if: ${{ needs.detect-noop.outputs.noop != 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Check Example Manifests
+        run: |
+          ./scripts/check-examples.py package/crds examples


### PR DESCRIPTION
### Description of your changes

In this PR, the check-examples job has been added to `provider-ci.yml` which is a reusable CI.

Fixes: https://github.com/upbound/uptest/issues/80

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually tested in `turkenf/uptest`, `turkenf/provider-gcp`, `turkenf/provider-aws` and `turkenf/provider-azure`