### PR TITLE
Add reusable workflow for publishing service artifacts

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -26,9 +26,7 @@ env:
   
 jobs:  
   publish-service-artifacts:
-    if: ${{ github.actor == 'OWNER' || github.actor == 'turkenf' || contains(github.event.repository.collaborators, github.actor) }}
     runs-on: ubuntu-22.04
-
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
@@ -84,7 +82,15 @@ jobs:
         run: make vendor vendor.check
 
       - name: Build Artifacts
-        run: echo make -j 3 SUBPACKAGES="${{ inputs.subpackages }}" build.all
+        id: build_artifacts
+        run: |
+          packages=($(echo ${{ inputs.subpackages }} | tr ' ' '\n'))
+          num_packages=${#packages[@]}
+          if [ $num_packages -gt 10 ]; then
+            num_packages=10
+          fi
+          make -j $num_packages SUBPACKAGES="${{ inputs.subpackages }}" build.all
+          echo "num_packages=$num_packages" >> $GITHUB_OUTPUT
         env:
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
@@ -97,4 +103,5 @@ jobs:
           path: _output/**
 
       - name: Publish Artifacts
-        run: echo make -j 3 SUBPACKAGES="${{ inputs.subpackages }}" BRANCH_NAME=main publish
+        run: |
+          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ inputs.subpackages }}" publish

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -1,0 +1,100 @@
+name: Provider Publish Service Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      subpackages:
+        description: 'Subpackages to be built individually (e.g. monolith config ec2)'
+        required: true
+        type: string
+    secrets:
+      UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
+        required: true
+      UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW:
+        required: true
+
+env:
+  # Common versions
+  GO_VERSION: '1.19'
+  GOLANGCI_VERSION: 'v1.50.0'
+  DOCKER_BUILDX_VERSION: 'v0.8.2'
+
+  # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
+  # step 'if env.XXX' != ""', so we copy these to succinctly test whether
+  # credentials have been provided before trying to run steps that need them.
+  UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+  
+jobs:  
+  publish-service-artifacts:
+    if: ${{ github.actor == 'OWNER' || github.actor == 'turkenf' || contains(github.event.repository.collaborators, github.actor) }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Login to Upbound
+        uses: docker/login-action@v2
+        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v3
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Artifacts
+        run: echo make -j 3 SUBPACKAGES="${{ inputs.subpackages }}" build.all
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+
+      - name: Upload Artifacts to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: _output/**
+
+      - name: Publish Artifacts
+        run: echo make -j 3 SUBPACKAGES="${{ inputs.subpackages }}" BRANCH_NAME=main publish

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -5,6 +5,11 @@ on:
     inputs:
       subpackages:
         description: 'Subpackages to be built individually (e.g. monolith config ec2)'
+        default: 'monolith'
+        required: false
+        type: string
+      version:
+        description: 'Provider version (e.g. v0.1.0)'
         required: true
         type: string
     secrets:
@@ -89,7 +94,7 @@ jobs:
           if [ $num_packages -gt 10 ]; then
             num_packages=10
           fi
-          make -j $num_packages SUBPACKAGES="${{ inputs.subpackages }}" build.all
+          make -j $num_packages SUBPACKAGES="${{ inputs.subpackages }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} build.all
           echo "num_packages=$num_packages" >> $GITHUB_OUTPUT
         env:
           # We're using docker buildx, which doesn't actually load the images it
@@ -104,4 +109,4 @@ jobs:
 
       - name: Publish Artifacts
         run: |
-          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ inputs.subpackages }}" publish
+          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ inputs.subpackages }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} publish


### PR DESCRIPTION
### Description of your changes

This PR adds a reusable workflow to be reused by official provider repositories for publishing service artifacts.


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest` and `turkenf/provider-azure`