### PR TITLE
Switch to matrix strategy to parallize provider family builds

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -46,11 +46,8 @@ jobs:
       indices: ${{ steps.calc.outputs.indices }}
     steps:
       - id: calc
-        env:
-          subpackages: ${{ inputs.subpackages }}
-          size: ${{ inputs.size }}
         run: |
-          python3 -c "import math, os; print(f'indices={list(range(0, math.ceil(len(os.getenv(\"subpackages\").split()) / int(os.getenv(\"size\")))))}')" >> "$GITHUB_OUTPUT"
+          python3 -c "import math; print(f'indices={list(range(0, math.ceil(len(\"${{ inputs.subpackages }}\".split()) / int(\"${{ inputs.size }}\"))))}')" >> "$GITHUB_OUTPUT"
 
   publish-service-artifacts:
     strategy:
@@ -117,12 +114,8 @@ jobs:
 
       - name: Calculate packages to build & push
         id: packages
-        env:
-          subpackages: ${{ inputs.subpackages }}
-          size: ${{ inputs.size }}
-          index: ${{ matrix.index }}
         run: |
-          echo target=$(python3 -c "import os; print(' '.join(os.getenv(\"subpackages\").split()[int(os.getenv(\"index\")) * int(os.getenv(\"size\")): (int(os.getenv(\"index\"))+1) * int(os.getenv(\"size\"))]))") >> "$GITHUB_OUTPUT"
+          echo target=$(python3 -c "print(' '.join(\"${{ inputs.subpackages }}\".split()[int(\"${{ matrix.index }}\") * int(\"${{ inputs.size }}\"): (int(\"${{ matrix.index }}\")+1) * int(\"${{ inputs.size }}\")]))") >> "$GITHUB_OUTPUT"
 
       - name: Build Artifacts
         id: build_artifacts

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -132,12 +132,6 @@ jobs:
           # builds by default. Specifying --load does so.
           BUILD_ARGS: "--load"
 
-      - name: Upload Artifacts to GitHub
-        uses: actions/upload-artifact@v3
-        with:
-          name: output
-          path: _output/**
-
       - name: Publish Artifacts
         run: |
           make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} CONCURRENCY="${{ inputs.concurrency }}" publish

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -12,6 +12,16 @@ on:
         description: 'Provider version (e.g. v0.1.0)'
         required: true
         type: string
+      size:
+        description: "Number of packages to build and push with each matrix build job"
+        required: true
+        default: 30
+        type: number
+      concurrency:
+        description: "Number of parallel package builds in each matrix job"
+        optional: true
+        default: 0
+        type: number
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -29,8 +39,25 @@ env:
   # credentials have been provided before trying to run steps that need them.
   UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
   
-jobs:  
+jobs:
+  index:
+    runs-on: ubuntu-22.04
+    outputs:
+      indices: ${{ steps.calc.outputs.indices }}
+    steps:
+      - id: calc
+        env:
+          subpackages: ${{ inputs.subpackages }}
+          size: ${{ inputs.size }}
+        run: |
+          python3 -c "import math, os; print(f'indices={list(range(0, math.ceil(len(os.getenv(\"subpackages\").split()) / int(os.getenv(\"size\")))))}')" >> "$GITHUB_OUTPUT"
+
   publish-service-artifacts:
+    strategy:
+      matrix:
+        index: ${{ fromJSON(needs.index.outputs.indices) }}
+
+    needs: index
     runs-on: ubuntu-22.04
     steps:
       - name: Setup QEMU
@@ -66,35 +93,46 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+        id: go_cache
+        run: |
+          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT && \
+          echo "mod_cache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.go.outputs.cache }}
+          path: ${{ steps.go_cache.outputs.cache }}
           key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v3
         with:
-          path: .work/pkg
+          path: ${{ steps.go_cache.outputs.mod_cache }}
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
+      - name: Calculate packages to build & push
+        id: packages
+        env:
+          subpackages: ${{ inputs.subpackages }}
+          size: ${{ inputs.size }}
+          index: ${{ matrix.index }}
+        run: |
+          echo target=$(python3 -c "import os; print(' '.join(os.getenv(\"subpackages\").split()[int(os.getenv(\"index\")) * int(os.getenv(\"size\")): (int(os.getenv(\"index\"))+1) * int(os.getenv(\"size\"))]))") >> "$GITHUB_OUTPUT"
+
       - name: Build Artifacts
         id: build_artifacts
         run: |
-          packages=($(echo ${{ inputs.subpackages }} | tr ' ' '\n'))
+          packages=($(echo ${{ steps.packages.outputs.target }} | tr ' ' '\n'))
           num_packages=${#packages[@]}
           if [ $num_packages -gt 10 ]; then
             num_packages=10
           fi
-          make -j $num_packages SUBPACKAGES="${{ inputs.subpackages }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} build.all
+          make -j $num_packages SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} build.all
           echo "num_packages=$num_packages" >> $GITHUB_OUTPUT
         env:
           # We're using docker buildx, which doesn't actually load the images it
@@ -109,4 +147,4 @@ jobs:
 
       - name: Publish Artifacts
         run: |
-          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ inputs.subpackages }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} publish
+          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} CONCURRENCY="${{ inputs.concurrency }}" publish


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR implements a matrix strategy for building provider families in smaller chunks. The `Provider Publish Service Artifacts` workflow now accepts a `size` parameter which specifies the maximum number of subpackages to be built in a matrix job and a new `concurrency` parameter which is passed to the `up xpkg batch` command as the value of the `--concurrent` option to control the maximum batch concurrency in the build pipeline.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested in the Github workflow of `upbound/provider-aws` with the corresponding `up xpkg batch` command.