### PR TITLE
Enable metrics collection for multiple provider pods

### DIFF
--- a/cmd/perf/internal/common/common.go
+++ b/cmd/perf/internal/common/common.go
@@ -41,6 +41,7 @@ type Result struct {
 	Metric        string
 	MetricUnit    string
 	Peak, Average float64
+	PodName       string
 }
 
 // ConstructPrometheusClient creates a Prometheus API Client
@@ -66,8 +67,10 @@ func ConstructTimeRange(startTime, endTime time.Time, stepDuration time.Duration
 }
 
 // ConstructResult creates a Result object from collected data
-func ConstructResult(value model.Value, metric, unit string) (*Result, error) {
-	result := &Result{}
+func ConstructResult(value model.Value, metric, unit string, podName string) (*Result, error) {
+	result := &Result{
+		PodName: podName,
+	}
 	matrix, ok := value.(model.Matrix)
 	if !ok {
 		return nil, errors.New("model cannot cast to matrix")
@@ -101,6 +104,7 @@ func CalculateAverageAndPeak(data []Data) (float64, float64) {
 
 // Print reports the results
 func (r Result) Print() {
+	log.Info(fmt.Sprintf("Pod: %s", r.PodName))
 	log.Info(fmt.Sprintf("Average %s: %f %s \n", r.Metric, r.Average, r.MetricUnit))
 	log.Info(fmt.Sprintf("Peak %s: %f %s \n", r.Metric, r.Peak, r.MetricUnit))
 }

--- a/cmd/perf/internal/common/common.go
+++ b/cmd/perf/internal/common/common.go
@@ -104,7 +104,9 @@ func CalculateAverageAndPeak(data []Data) (float64, float64) {
 
 // Print reports the results
 func (r Result) Print() {
-	log.Info(fmt.Sprintf("Pod: %s", r.PodName))
+	if r.PodName != "" {
+		log.Info(fmt.Sprintf("Pod: %s", r.PodName))
+	}
 	log.Info(fmt.Sprintf("Average %s: %f %s \n", r.Metric, r.Average, r.MetricUnit))
 	log.Info(fmt.Sprintf("Peak %s: %f %s \n", r.Metric, r.Peak, r.MetricUnit))
 }

--- a/cmd/perf/internal/quantify.go
+++ b/cmd/perf/internal/quantify.go
@@ -126,7 +126,8 @@ func (o *QuantifyOptions) Run(_ *cobra.Command, _ []string) error {
 // processPods calculated metrics for provider pods
 func (o *QuantifyOptions) processPods(timeToReadinessResults []common.Result) error {
 	// Initialize aggregated results
-	var aggregatedMemoryResult, aggregatedCPURateResult common.Result
+	var aggregatedMemoryResult = &common.Result{Metric: "Memory", MetricUnit: "Bytes"}
+	var aggregatedCPURateResult = &common.Result{Metric: "CPU", MetricUnit: "Rate"}
 
 	for _, providerPod := range o.providerPods {
 		providerPod = strings.TrimSpace(providerPod)

--- a/cmd/perf/internal/quantify.go
+++ b/cmd/perf/internal/quantify.go
@@ -125,7 +125,7 @@ func (o *QuantifyOptions) Run(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrap(err, "cannot collect memory data")
 		}
-		memoryResult, err := common.ConstructResult(queryResultMemory, "Memory", "Bytes")
+		memoryResult, err := common.ConstructResult(queryResultMemory, "Memory", "Bytes", providerPod)
 		if err != nil {
 			return errors.Wrap(err, "cannot construct memory results")
 		}
@@ -139,7 +139,7 @@ func (o *QuantifyOptions) Run(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrap(err, "cannot collect cpu data")
 		}
-		cpuRateResult, err := common.ConstructResult(queryResultCPURate, "CPU", "Rate")
+		cpuRateResult, err := common.ConstructResult(queryResultCPURate, "CPU", "Rate", providerPod)
 		if err != nil {
 			return errors.Wrap(err, "cannot construct cpu results")
 		}

--- a/cmd/perf/internal/quantify.go
+++ b/cmd/perf/internal/quantify.go
@@ -115,6 +115,16 @@ func (o *QuantifyOptions) Run(_ *cobra.Command, _ []string) error {
 	log.Infof("Results\n------------------------------------------------------------\n")
 	log.Infof("Experiment Duration: %f seconds\n", o.endTime.Sub(o.startTime).Seconds())
 	time.Sleep(60 * time.Second)
+
+	err := o.processPods(timeToReadinessResults)
+	if err != nil {
+		return errors.Wrap(err, "cannot process pods")
+	}
+	return nil
+}
+
+// processPods calculated metrics for provider pods
+func (o *QuantifyOptions) processPods(timeToReadinessResults []common.Result) error {
 	// Initialize aggregated results
 	var aggregatedMemoryResult, aggregatedCPURateResult common.Result
 

--- a/cmd/perf/internal/quantify.go
+++ b/cmd/perf/internal/quantify.go
@@ -18,6 +18,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ import (
 
 // QuantifyOptions represents the options of quantify command
 type QuantifyOptions struct {
-	providerPod       string
+	providerPods      []string
 	providerNamespace string
 	mrPaths           map[string]int
 	cmd               *cobra.Command
@@ -56,12 +57,12 @@ func NewCmdQuantify() *cobra.Command {
 			"reports them. When you execute this tool an end-to-end experiment will run.",
 		Example: "provider-scale --mrs ./internal/providerScale/manifests/virtualnetwork.yaml=2 " +
 			"--mrs ./internal/providerScale/manifests/loadbalancer.yaml=2" +
-			"--provider-pod crossplane-provider-jet-azure " +
+			"--provider-pods crossplane-provider-jet-azure " +
 			"--provider-namespace crossplane-system",
 		RunE: o.Run,
 	}
 
-	o.cmd.Flags().StringVar(&o.providerPod, "provider-pod", "", "Pod name of provider")
+	o.cmd.Flags().StringSliceVarP(&o.providerPods, "provider-pods", "p", []string{}, "Names of the provider pods. Multiple names can be specified, separated by commas (spaces are ignored).")
 	o.cmd.Flags().StringVar(&o.providerNamespace, "provider-namespace", "crossplane-system",
 		"Namespace name of provider")
 	o.cmd.Flags().StringToIntVar(&o.mrPaths, "mrs", nil, "Managed resource templates that will be deployed")
@@ -71,7 +72,7 @@ func NewCmdQuantify() *cobra.Command {
 	o.cmd.Flags().StringVar(&o.nodeIP, "node", "", "Node IP")
 	o.cmd.Flags().DurationVar(&o.timeout, "timeout", 120*time.Minute, "Timeout for the experiment")
 
-	if err := o.cmd.MarkFlagRequired("provider-pod"); err != nil {
+	if err := o.cmd.MarkFlagRequired("provider-pods"); err != nil {
 		panic(err)
 	}
 	if err := o.cmd.MarkFlagRequired("mrs"); err != nil {
@@ -114,28 +115,52 @@ func (o *QuantifyOptions) Run(_ *cobra.Command, _ []string) error {
 	log.Infof("Results\n------------------------------------------------------------\n")
 	log.Infof("Experiment Duration: %f seconds\n", o.endTime.Sub(o.startTime).Seconds())
 	time.Sleep(60 * time.Second)
-	queryResultMemory, err := o.CollectData(fmt.Sprintf(`sum(node_namespace_pod_container:container_memory_working_set_bytes{pod="%s", namespace="%s"})`,
-		o.providerPod, o.providerNamespace))
-	if err != nil {
-		return errors.Wrap(err, "cannot collect memory data")
+	// Initialize aggregated results
+	var aggregatedMemoryResult, aggregatedCPURateResult common.Result
+
+	for _, providerPod := range o.providerPods {
+		providerPod = strings.TrimSpace(providerPod)
+		queryResultMemory, err := o.CollectData(fmt.Sprintf(`sum(node_namespace_pod_container:container_memory_working_set_bytes{pod="%s", namespace="%s"})`,
+			providerPod, o.providerNamespace))
+		if err != nil {
+			return errors.Wrap(err, "cannot collect memory data")
+		}
+		memoryResult, err := common.ConstructResult(queryResultMemory, "Memory", "Bytes")
+		if err != nil {
+			return errors.Wrap(err, "cannot construct memory results")
+		}
+		// Update aggregated memory result
+		aggregatedMemoryResult.Average += memoryResult.Average
+		if memoryResult.Peak > aggregatedMemoryResult.Peak {
+			aggregatedMemoryResult.Peak = memoryResult.Peak
+		}
+
+		queryResultCPURate, err := o.CollectData(fmt.Sprintf(`instance:node_cpu_utilisation:rate5m{instance="%s"} * 100`, o.nodeIP))
+		if err != nil {
+			return errors.Wrap(err, "cannot collect cpu data")
+		}
+		cpuRateResult, err := common.ConstructResult(queryResultCPURate, "CPU", "Rate")
+		if err != nil {
+			return errors.Wrap(err, "cannot construct cpu results")
+		}
+		// Update aggregated CPU rate result
+		aggregatedCPURateResult.Average += cpuRateResult.Average
+		if cpuRateResult.Peak > aggregatedCPURateResult.Peak {
+			aggregatedCPURateResult.Peak = cpuRateResult.Peak
+		}
+
+		for _, timeToReadinessResult := range timeToReadinessResults {
+			timeToReadinessResult.Print()
+		}
+		memoryResult.Print()
+		cpuRateResult.Print()
 	}
-	memoryResult, err := common.ConstructResult(queryResultMemory, "Memory", "Bytes")
-	if err != nil {
-		return errors.Wrap(err, "cannot construct memory results")
+
+	if len(o.providerPods) > 1 {
+		log.Infof("\nAggregated Results\n------------------------------------------------------------\n")
+		aggregatedMemoryResult.Print()
+		aggregatedCPURateResult.Print()
 	}
-	qureyResultCPURate, err := o.CollectData(fmt.Sprintf(`instance:node_cpu_utilisation:rate5m{instance="%s"} * 100`, o.nodeIP))
-	if err != nil {
-		return errors.Wrap(err, "cannot collect cpu data")
-	}
-	cpuRateResult, err := common.ConstructResult(qureyResultCPURate, "CPU", "Rate")
-	if err != nil {
-		return errors.Wrap(err, "cannot construct cpu results")
-	}
-	for _, timeToReadinessResult := range timeToReadinessResults {
-		timeToReadinessResult.Print()
-	}
-	memoryResult.Print()
-	cpuRateResult.Print()
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

As part of the resources utilization testing, we are using this tool for collecting Prometheus metrics from provider pods. This PR adds a functionality of collecting Prometheus metrics from multiple provider pods while keeping the functional backwards compatibility.

There is a breaking change in the command line parameters where the flag `--provider-pod` changes to `--provider-pods` to better describe the functionality.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally, sample test output:

```text
➜ just run_tests gcp 2
time="2023-05-11T17:55:38+02:00" level=info msg="Experiment Started 2023-05-11 17:55:38.367240392 +0200 CEST m=+0.013268059\n\n"
bucket.storage.gcp.upbound.io/test1 created
bucket.storage.gcp.upbound.io/test2 created
time="2023-05-11T17:55:39+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:55:50+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:00+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:10+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:20+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:30+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:40+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:50+02:00" level=info msg="Checking readiness of resources..."
time="2023-05-11T17:56:50+02:00" level=info msg="Calculating readiness time of resources..."
time="2023-05-11T17:56:50+02:00" level=info msg="Deleting resources..."
bucket.storage.gcp.upbound.io "test1" deleted
bucket.storage.gcp.upbound.io "test2" deleted
time="2023-05-11T17:57:55+02:00" level=info msg="\nExperiment Ended 2023-05-11 17:57:55.33495993 +0200 CEST m=+136.980987669\n\n"
time="2023-05-11T17:57:55+02:00" level=info msg="Results\n------------------------------------------------------------\n"
time="2023-05-11T17:57:55+02:00" level=info msg="Experiment Duration: 136.967720 seconds\n"
time="2023-05-11T17:58:55+02:00" level=info msg="Average Time to Readiness of Bucket: 64.500000 seconds \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak Time to Readiness of Bucket: 65.000000 seconds \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Pod: upbound-release-candidates-provider-family-gcp-9d0a6cba600mml5q"
time="2023-05-11T17:58:55+02:00" level=info msg="Average Memory: 18956433.543147 Bytes \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak Memory: 19038208.000000 Bytes \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Pod: upbound-release-candidates-provider-family-gcp-9d0a6cba600mml5q"
time="2023-05-11T17:58:55+02:00" level=info msg="Average CPU: 1.494668 Rate \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak CPU: 2.197685 Rate \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Average Time to Readiness of Bucket: 64.500000 seconds \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak Time to Readiness of Bucket: 65.000000 seconds \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Pod: upbound-release-candidates-provider-gcp-storage-3c1d8cc0c02jrlx"
time="2023-05-11T17:58:55+02:00" level=info msg="Average Memory: NaN Bytes \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak Memory: 0.000000 Bytes \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Pod: upbound-release-candidates-provider-gcp-storage-3c1d8cc0c02jrlx"
time="2023-05-11T17:58:55+02:00" level=info msg="Average CPU: 1.494668 Rate \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak CPU: 2.197685 Rate \n"
time="2023-05-11T17:58:55+02:00" level=info msg="\nAggregated Results\n------------------------------------------------------------\n"
time="2023-05-11T17:58:55+02:00" level=info msg="Average CPU: NaN  \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak CPU: 19038208.000000  \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Average Memory: 2.989335  \n"
time="2023-05-11T17:58:55+02:00" level=info msg="Peak Memory: 2.197685  \n"
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
