### PR TITLE
Remove "optional: true" from inputs of publish service artifacts reusable workflow

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -14,14 +14,14 @@ on:
         type: string
       size:
         description: "Number of packages to build and push with each matrix build job"
+        default: '30'
         required: true
-        default: 30
-        type: number
+        type: string
       concurrency:
         description: "Number of parallel package builds in each matrix job"
-        optional: true
-        default: 1
-        type: number
+        default: '1'
+        required: false
+        type: string
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -136,4 +136,4 @@ jobs:
 
       - name: Publish Artifacts
         run: |
-          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates VERSION=${{ inputs.version }} CONCURRENCY="${{ inputs.concurrency }}" publish
+          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound-release-candidates XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound-release-candidates BRANCH_NAME=main VERSION=${{ inputs.version }} CONCURRENCY="${{ inputs.concurrency }}" publish


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relevant PR: https://github.com/upbound/provider-gcp/pull/302

The PR fixes an issue with the `Publish Service Artifacts` Github workflow, where an invalid `optional: true` field exists in the `concurrency` input.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Please see https://github.com/upbound/provider-gcp/pull/302 and https://github.com/upbound/provider-gcp/actions/runs/4963402570.