### PR TITLE
Make test resource name a bit more complex

### DIFF
--- a/cmd/perf/internal/managed/managed.go
+++ b/cmd/perf/internal/managed/managed.go
@@ -88,7 +88,7 @@ func applyResources(mrTemplatePaths map[string]int) (string, error) {
 		}
 
 		for i := 1; i <= count; i++ {
-			m["metadata"].(map[interface{}]interface{})["name"] = fmt.Sprintf("test%d", i)
+			m["metadata"].(map[interface{}]interface{})["name"] = fmt.Sprintf("testperfrun%d", i)
 
 			b, err := yaml.Marshal(m)
 			if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Currently, the name of the MR under test will be auto generated as `test[number]` which will became a cloud service name.
Since this is a pretty common pattern, there might be accidental resources override because someone else can create a resource with the same name. This PR extends the test resource name with additional words to make the accidental override more unlikely.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manual local test.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
