### PR TITLE
Accept : or ? in the Makefile export statement for TERRAFORM_PROVIDER_VERSION in native-provider-bump.yml Github workflow

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Bump native provider version in Makefile
         id: bump-mk
         run: |
-          sed -i -E "s/^(export[[:space:]]+TERRAFORM_PROVIDER_VERSION[[:space:]]*:=[[:space:]]*).+/\1$(curl -sL 'https://registry.terraform.io/v1/providers/${{ inputs.provider-source }}' | jq -r .version)/" Makefile
+          sed -i -E "s/^(export[[:space:]]+TERRAFORM_PROVIDER_VERSION[[:space:]]*(:|\?)=[[:space:]]*).+/\1$(curl -sL 'https://registry.terraform.io/v1/providers/${{ inputs.provider-source }}' | jq -r .version)/" Makefile
           echo "bumped=$(git diff --name-only Makefile)" >> $GITHUB_OUTPUT
           echo "version=$(curl -sL 'https://registry.terraform.io/v1/providers/${{ inputs.provider-source }}' | jq -r .version)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
@turkenf figured out that we cannot currently open automated native provider version bump PRs for `upbound/provider-azure` because in that repo's Makefile, `TERRAFORM_PROVIDER_VERSION` is [optionally exported](https://github.com/upbound/provider-azure/blob/c8842bfb49800fdfa8092aa25e82bec9ab828e8a/Makefile#L11). This PR proposes a change to also handle the `?`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
We manually tested the regular expression change with @turkenf on `upbound/provider-gcp` & `upbound/provider-azure` Makefiles.