### PR TITLE
Add provider-list tool to dump the names of the required provider family packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PLATFORMS ?= linux_amd64 linux_arm64 darwin_amd64 darwin_arm64
 # Setup Go
 GO_REQUIRED_VERSION = 1.19
 GOLANGCILINT_VERSION ?= 1.50.0
-GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/uptest $(GO_PROJECT)/cmd/updoc $(GO_PROJECT)/cmd/ttr $(GO_PROJECT)/cmd/perf
+GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/uptest $(GO_PROJECT)/cmd/updoc $(GO_PROJECT)/cmd/ttr $(GO_PROJECT)/cmd/perf $(GO_PROJECT)/cmd/provider-list
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal
 GO111MODULE = on

--- a/cmd/provider-list/converter.go
+++ b/cmd/provider-list/converter.go
@@ -28,7 +28,7 @@ import (
 var SSOPNames = map[string]struct{}{}
 
 // GetSSOPNameFromManagedResource collects the new provider name from MR
-func GetSSOPNameFromManagedResource(u migration.UnstructuredWithMetadata) error { //nolint:unparam // Because of the signature of preprocessor interface
+func GetSSOPNameFromManagedResource(u migration.UnstructuredWithMetadata) error {
 	newProviderName := getProviderAndServiceName(u.Object.GroupVersionKind().Group)
 	if newProviderName != "" {
 		SSOPNames[newProviderName] = struct{}{}
@@ -37,7 +37,7 @@ func GetSSOPNameFromManagedResource(u migration.UnstructuredWithMetadata) error 
 }
 
 // GetSSOPNameFromComposition collects the new provider name from Composition
-func GetSSOPNameFromComposition(u migration.UnstructuredWithMetadata) error { //nolint:deadcode // It will be used in the main of this tool
+func GetSSOPNameFromComposition(u migration.UnstructuredWithMetadata) error {
 	composition, err := migration.ToComposition(u.Object)
 	if err != nil {
 		return errors.Wrap(err, "unstructured object cannot be converted to composition")

--- a/cmd/provider-list/main.go
+++ b/cmd/provider-list/main.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// main package for the provider-list tool that can be used to dump the names
+// of the required provider family (service-scoped provider) packages
+// that satisfy:
+//   - All managed resources and Crossplane Compositions observed in a cluster.
+//   - All Crossplane Compositions observed in the source tree of
+//     a Crossplane Configuration package.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/alecthomas/kong"
+	"github.com/pkg/errors"
+	"github.com/upbound/upjet/pkg/migration"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	defaultKubeConfig = ".kube/config"
+)
+
+// Options represents the available subcommands of provider-list:
+// "generate" and "upload".
+type Options struct {
+	RegistryOrg string `name:"regorg" required:"" default:"xpkg.upbound.io/upbound" help:"<registry host>/<organization> for the provider family packages."`
+	Version     string `name:"family-version" required:"" help:"Version of the provider family packages."`
+	// sub-commands
+	Local struct {
+		Path string `name:"path" required:"" help:"Source directory for the Crossplane Configuration package."`
+	} `kong:"cmd"`
+	Cluster struct {
+		KubeConfig string `name:"kubeconfig" optional:"" help:"Path to the kubeconfig to use."`
+	} `kong:"cmd"`
+}
+
+func main() {
+	opts := &Options{}
+	kongCtx := kong.Parse(opts, kong.Name("provider-list"),
+		kong.Description("Upbound provider families package dependency listing tool"),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact:   true,
+			FlagsLast: true,
+			Summary:   true,
+		}))
+
+	r := migration.NewRegistry(runtime.NewScheme())
+	r.RegisterPreProcessor(migration.CategoryManaged, migration.PreProcessor(GetSSOPNameFromManagedResource))
+	r.RegisterPreProcessor(migration.CategoryComposition, migration.PreProcessor(GetSSOPNameFromComposition))
+	kongCtx.FatalIfErrorf(r.AddCompositionTypes(), "Failed to register the Crossplane Composition types with the migration registry")
+
+	var source migration.Source
+	var err error
+	switch kongCtx.Command() {
+	case "local":
+		source, err = localListing(opts)
+	case "cluster":
+		source, err = clusterListing(opts, r)
+	}
+	kongCtx.FatalIfErrorf(err, "Failed to initialize the migration source")
+
+	pg := migration.NewPlanGenerator(r, source, nil, migration.WithSkipGVKs(schema.GroupVersionKind{}))
+	kongCtx.FatalIfErrorf(pg.GeneratePlan(), "Failed to list the required provider family packages")
+	providers := make([]string, 0, len(SSOPNames))
+	for p := range SSOPNames {
+		providers = append(providers, p)
+	}
+	sort.Strings(providers)
+	logger := log.New(os.Stdout, "", 0)
+	for _, p := range providers {
+		logger.Printf("%s", fmt.Sprintf("%s/%s:%s", opts.RegistryOrg, p, opts.Version))
+	}
+}
+
+func clusterListing(opts *Options, r *migration.Registry) (migration.Source, error) {
+	if len(opts.Cluster.KubeConfig) == 0 {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get user's home")
+		}
+		opts.Cluster.KubeConfig = filepath.Join(homeDir, defaultKubeConfig)
+	}
+	source, err := migration.NewKubernetesSourceFromKubeConfig(opts.Cluster.KubeConfig,
+		migration.WithCategories([]migration.Category{"managed"}), migration.WithRegistry(r))
+	return source, errors.Wrap(err, "failed to initialize the migration Kubernetes source")
+}
+
+func localListing(opts *Options) (migration.Source, error) {
+	source, err := migration.NewFileSystemSource(opts.Local.Path)
+	return source, errors.Wrap(err, "failed to initialize the migration FileSystem source")
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Depends on:
- #117 
- https://github.com/upbound/upjet/pull/212

This PR adds the `provider-list` tool that can be used to dump the names of the required provider family (service-scoped provider) packages that satisfy:
- All managed resources and Crossplane Compositions observed in a cluster, or
- All Crossplane Compositions observed in the source tree of a Crossplane Configuration package.

Only managed resources belonging to one of the official monolithic providers with available families (i.e., `upbound/provider-{aws,gcp,azure}`) are considered.

```
Usage: provider-list --regorg="xpkg.upbound.io/upbound" --family-version=STRING <command>

Upbound provider families package dependency listing tool

Commands:
  local
  cluster

Flags:
  -h, --help                                Show context-sensitive help.
      --regorg="xpkg.upbound.io/upbound"    <registry host>/<organization> for the provider family packages.
      --family-version=STRING               Version of the provider family packages.

Run "provider-list <command> --help" for more information on a command.
```

```
Usage: provider-list local --regorg="xpkg.upbound.io/upbound" --family-version=STRING --path=STRING

Flags:
  -h, --help                                Show context-sensitive help.
      --regorg="xpkg.upbound.io/upbound"    <registry host>/<organization> for the provider family packages.
      --family-version=STRING               Version of the provider family packages.

      --path=STRING                         Source directory for the Crossplane Configuration package.
```

```
Usage: provider-list cluster --regorg="xpkg.upbound.io/upbound" --family-version=STRING

Flags:
  -h, --help                                Show context-sensitive help.
      --regorg="xpkg.upbound.io/upbound"    <registry host>/<organization> for the provider family packages.
      --family-version=STRING               Version of the provider family packages.

      --kubeconfig=STRING                   Path to the kubeconfig to use.
```

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Both the `local` and `cluster` subcommands have been tested in tandem with https://github.com/upbound/upjet/pull/212 & #117. Sample runs are as follows:

```
> provider-list local --family-version v0.37.0 --path ./upbound/platform-ref-gcp/package

xpkg.upbound.io/upbound/provider-gcp-cloudplatform:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-compute:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-container:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-servicenetworking:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-sql:v0.37.0
```

```
> provider-list cluster --family-version v0.37.0

xpkg.upbound.io/upbound/provider-aws-rds:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-cloudplatform:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-compute:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-servicenetworking:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-sql:v0.37.0
```
