### PR TITLE
Remove "version" parameter from the "Provider Publish Service Artifacts" reusable workflow

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -8,10 +8,6 @@ on:
         default: 'monolith'
         required: false
         type: string
-      version:
-        description: 'Provider version (e.g. v0.1.0)'
-        required: true
-        type: string
       size:
         description: "Number of packages to build and push with each matrix build job"
         default: '30'
@@ -127,7 +123,7 @@ jobs:
           if [ $num_packages -gt 10 ]; then
             num_packages=10
           fi
-          make -j $num_packages SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound VERSION=${{ inputs.version }} build.all
+          make -j $num_packages SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound build.all
           echo "num_packages=$num_packages" >> $GITHUB_OUTPUT
         env:
           # We're using docker buildx, which doesn't actually load the images it
@@ -136,4 +132,4 @@ jobs:
 
       - name: Publish Artifacts
         run: |
-          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound BRANCH_NAME=main VERSION=${{ inputs.version }} CONCURRENCY="${{ inputs.concurrency }}" publish
+          make -j ${{ steps.build_artifacts.outputs.num_packages }} SUBPACKAGES="${{ steps.packages.outputs.target }}" XPKG_REG_ORGS=xpkg.upbound.io/upbound XPKG_REG_ORGS_NO_PROMOTE=xpkg.upbound.io/upbound CONCURRENCY="${{ inputs.concurrency }}" publish


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The current "Publish Service Artifacts" reusable workflow is for power users as it accepts the provider versions to be published as a reusable workflow parameter. I don't think we need this flexibility anymore as it may have some unwanted consequences if not properly used. This PR proposes to remove that parameter.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
To be tested with the calling jobs in `upbound/provider-{aws, azure, gcp}`.