### PR TITLE
Performance tool can accept test MRs via URLs

### DIFF
--- a/cmd/perf/internal/managed/managed.go
+++ b/cmd/perf/internal/managed/managed.go
@@ -236,7 +236,10 @@ func readYamlFile(pathOrURL string) (map[interface{}]interface{}, error) {
 			return nil, errors.Wrap(err, "cannot fetch URL")
 		}
 		defer func() {
-			_ = resp.Body.Close()
+			err := resp.Body.Close()
+			if err != nil {
+				log.Fatal("cannot close response body")
+			}
 		}()
 
 		if resp.StatusCode != http.StatusOK {

--- a/cmd/perf/internal/quantify.go
+++ b/cmd/perf/internal/quantify.go
@@ -56,7 +56,7 @@ func NewCmdQuantify() *cobra.Command {
 		Short: "This tool collects CPU & Memory Utilization and time to readiness of MRs metrics of providers and " +
 			"reports them. When you execute this tool an end-to-end experiment will run.",
 		Example: "provider-scale --mrs ./internal/providerScale/manifests/virtualnetwork.yaml=2 " +
-			"--mrs ./internal/providerScale/manifests/loadbalancer.yaml=2" +
+			"--mrs https:... OR ./internal/providerScale/manifests/loadbalancer.yaml=2" +
 			"--provider-pods crossplane-provider-jet-azure " +
 			"--provider-namespace crossplane-system",
 		RunE: o.Run,
@@ -65,7 +65,7 @@ func NewCmdQuantify() *cobra.Command {
 	o.cmd.Flags().StringSliceVarP(&o.providerPods, "provider-pods", "p", []string{}, "Names of the provider pods. Multiple names can be specified, separated by commas (spaces are ignored).")
 	o.cmd.Flags().StringVar(&o.providerNamespace, "provider-namespace", "crossplane-system",
 		"Namespace name of provider")
-	o.cmd.Flags().StringToIntVar(&o.mrPaths, "mrs", nil, "Managed resource templates that will be deployed")
+	o.cmd.Flags().StringToIntVar(&o.mrPaths, "mrs", nil, "Managed resource templates that will be deployed, provided as local paths or URLs")
 	o.cmd.Flags().StringVar(&o.address, "address", "http://localhost:9090", "Address of Prometheus service")
 	o.cmd.Flags().DurationVar(&o.stepDuration, "step-duration", 1*time.Second, "Step duration between two data points")
 	o.cmd.Flags().BoolVar(&o.clean, "clean", true, "Delete deployed MRs")


### PR DESCRIPTION
### Description of your changes

Managed resources used for performance testing are read from disk and passed as arguments to the CLI. This commit introduces changes to the CLI so that test MRs can now be passed via URLs.

This change is needed to add more flexible test scenarios for the performance CI pipeline.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/team-extensions/issues/177

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Locally running the tool with URL MRs
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
