### PR TITLE
Inherit golangci-lint version from `build` submodule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ PLATFORMS ?= linux_amd64 linux_arm64 darwin_amd64 darwin_arm64
 # ====================================================================================
 # Setup Go
 GO_REQUIRED_VERSION = 1.19
-GOLANGCILINT_VERSION ?= 1.50.0
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.54.0
+
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/uptest $(GO_PROJECT)/cmd/updoc $(GO_PROJECT)/cmd/ttr $(GO_PROJECT)/cmd/perf $(GO_PROJECT)/cmd/linter/lint-provider-family
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal


### PR DESCRIPTION


<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Shamelessly copy Yury Tsarev's (@ytsarev) following changes to other repos, such as upbound/provider-aws#829:

* Motivation: golangci-lint base run was freezing on Mac M1 and go1.20.5.
* Remove the version override in the Makefile with the comment and consume the latest version from the build
* Presumably, it was a fix around consume a lot of memory on go1.20rc3 consume a lot of memory on go1.20rc3 golangci/golangci-lint#3470 helped in the latest golangci-lint release
* Update build submodule to consume upbound/build#238

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've run `make`. I've already developed upbound/uptest#132 using this PR, but please let me know if we might have other concerns for merging.
