### PR TITLE
Add ability to publish family provider docs for provider-updoc workflow

### DIFF
--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -2,13 +2,19 @@ name: Updoc
 
 on:
   workflow_call:
+    inputs:
+      subpackages:
+        description: "Subpackages to be published individually (e.g. monolith config ec2)"
+        default: "monolith"
+        required: false
+        type: string
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA:
         required: true
 
 env:
-  GO_VERSION: '1.19'
-  UPTEST_VERSION: '83bd901'
+  GO_VERSION: "1.19"
+  UPTEST_VERSION: "83bd901"
 
 jobs:
   publish-docs:
@@ -53,10 +59,19 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: sa.json
           PROVIDER_NAME: ${GITHUB_REPOSITORY#*/}
           VER_MAJOR_MINOR: v${GITHUB_REF#"refs/heads/release-"}
+          SUBPACKAGES: ${{ inputs.subpackages }}
         run: |
           if [[ "${GITHUB_REF##*/}" == release-* ]]; then
-            echo "Publishing Docs for ${{ env.PROVIDER_NAME }}, ${{ env.VER_MAJOR_MINOR }}"
-            go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir=./docs --name=${{ env.PROVIDER_NAME }} --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
+            for s in $SUBPACKAGES; do
+              FAMILY_PROVIDER_NAME="${{ env.PROVIDER_NAME }}-$s"
+              DOCS_DIR="./docs/family"
+                if [ $s == 'monolith' ]; then
+                  FAMILY_PROVIDER_NAME="${{ env.PROVIDER_NAME }}"
+                  DOCS_DIR="./docs/monolith"
+                fi
+                echo "Publishing Docs for $FAMILY_PROVIDER_NAME, ${{ env.VER_MAJOR_MINOR }}"
+                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir=“${DOCS_DIR}” --name=“${FAMILY_PROVIDER_NAME}” --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
+            done
           else
             echo "This job can only be run on release branches"
             exit 1

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -3,9 +3,9 @@ name: Updoc
 on:
   workflow_call:
     inputs:
-      subpackages:
-        description: "Subpackages to be published individually (e.g. monolith config ec2)"
-        default: "monolith"
+      providers:
+        description: 'Family provider names for which to publish the docs, e.g., "monolith config". The provider names should be space-delimited.'
+        default: 'monolith'
         required: false
         type: string
     secrets:
@@ -59,18 +59,21 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: sa.json
           PROVIDER_NAME: ${GITHUB_REPOSITORY#*/}
           VER_MAJOR_MINOR: v${GITHUB_REF#"refs/heads/release-"}
-          SUBPACKAGES: ${{ inputs.subpackages }}
+          SUBPACKAGES: ${{ inputs.providers }}
         run: |
           if [[ "${GITHUB_REF##*/}" == release-* ]]; then
             for s in $SUBPACKAGES; do
-              FAMILY_PROVIDER_NAME="${{ env.PROVIDER_NAME }}-$s"
+              PROVIDER_PACKAGE_NAME="${{ env.PROVIDER_NAME }}-$s"
               DOCS_DIR="./docs/family"
                 if [ $s == 'monolith' ]; then
-                  FAMILY_PROVIDER_NAME="${{ env.PROVIDER_NAME }}"
+                  PROVIDER_PACKAGE_NAME="${{ env.PROVIDER_NAME }}"
                   DOCS_DIR="./docs/monolith"
+                elif [ $s == 'config' ]; then
+                  PROVIDER_PACKAGE_NAME="provider-family-${GITHUB_REPOSITORY#*-}"
+                  DOCS_DIR="./docs/family"
                 fi
-                echo "Publishing Docs for $FAMILY_PROVIDER_NAME, ${{ env.VER_MAJOR_MINOR }}"
-                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir=“${DOCS_DIR}” --name=“${FAMILY_PROVIDER_NAME}” --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
+                echo "Publishing Docs for $PROVIDER_PACKAGE_NAME, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"
+                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir=“${DOCS_DIR}” --name=“${PROVIDER_PACKAGE_NAME}” --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
             done
           else
             echo "This job can only be run on release branches"


### PR DESCRIPTION
### Description of your changes

This PR adds the ability to publish family provider docs for `provider-updoc` workflow

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest` and `turkenf/provider-gcp`

Result of the upload docs step of the updoc workflow triggered in `turkenf/provider-gcp`:

![Screenshot 2023-09-27 at 17 17 46](https://github.com/upbound/uptest/assets/103541666/a6491af1-5ada-4871-88df-024cb336ab54)

Manual publishing for `provider-family-gcp` v0.33.0 family provider:

![Screenshot 2023-09-27 at 17 18 42](https://github.com/upbound/uptest/assets/103541666/6509d4e7-58de-4804-9af4-3e9a6f42300d)
