### PR TITLE
Allow large runners to be configured by an input

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -3,6 +3,10 @@ name: Run Uptest
 on:
   workflow_call:
     inputs:
+      large-runner:
+        required: false
+        type: string
+        default: "[e2-standard-8, linux]"
       trigger-keyword:
         description: 'Keyword to trigger the workflow, defaults to /test-examples'
         default: '/test-examples'
@@ -27,7 +31,7 @@ on:
 
 jobs:
   debug:
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     steps:
       - name: Debug
         run: |
@@ -40,7 +44,7 @@ jobs:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
             github.event.issue.pull_request &&
             contains(github.event.comment.body, inputs.trigger-keyword ) }}
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     outputs:
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
       example_hash: ${{ steps.get-example-list-name.outputs.example-hash }}
@@ -97,7 +101,7 @@ jobs:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, inputs.trigger-keyword ) }}
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     needs: get-example-list
 
     steps:

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -3,6 +3,10 @@ name: Provider CI
 on:
   workflow_call:
     inputs:
+      large-runner:
+        required: false
+        type: string
+        default: "[e2-standard-8, linux]"
       upjet-based-provider:
         required: false
         type: boolean
@@ -65,7 +69,7 @@ jobs:
         run: |
           make schema-version-diff
   lint:
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -273,7 +277,7 @@ jobs:
         run: make local-deploy
 
   publish-artifacts:
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -3,6 +3,10 @@ name: Provider Publish Service Artifacts
 on:
   workflow_call:
     inputs:
+      large-runner:
+        required: false
+        type: string
+        default: "[e2-standard-8, linux]"
       subpackages:
         description: 'Subpackages to be built individually (e.g. monolith config ec2)'
         default: 'monolith'
@@ -38,7 +42,7 @@ env:
   
 jobs:
   index:
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     outputs:
       indices: ${{ steps.calc.outputs.indices }}
     steps:
@@ -52,7 +56,7 @@ jobs:
         index: ${{ fromJSON(needs.index.outputs.indices) }}
 
     needs: index
-    runs-on: [e2-standard-8, linux]
+    runs-on: ${{ fromJSON(inputs.large-runner) }}
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1


### PR DESCRIPTION
Some of the reusable workflow jobs in here refer to large runners which exist within the upbound GitHub organisation. These can't be invoked by forks:

> Called workflows cannot be queued onto self-hosted runners across organisations/enterprises. Failed to queue this job. Labels: 'e2-standard-8 , linux'.

If we make this into an input then callers can customise it themselves and still continue to use the reusable workflows to publish their providers.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've run it [here](https://github.com/grafana/crossplane-provider-aws/actions/runs/6234509504). What works is using the built-in runners like `ubuntu-latest`. Specifying our own runner labels doesn't work still. But at least this lets us run the reusable workflows. This inspired me to [start a discussion thread](https://github.com/orgs/community/discussions/67583) on the github community.
