### PR TITLE
Fix quotes causing updoc crash

### DIFF
--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -73,7 +73,7 @@ jobs:
                   DOCS_DIR="./docs/family"
                 fi
                 echo "Publishing Docs for $PROVIDER_PACKAGE_NAME, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"
-                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir=“${DOCS_DIR}” --name=“${PROVIDER_PACKAGE_NAME}” --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
+                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir="${DOCS_DIR}" --name="${PROVIDER_PACKAGE_NAME}" --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
             done
           else
             echo "This job can only be run on release branches"


### PR DESCRIPTION
### Description of your changes

This PR fixes quotes in `provider-updoc` workflow. 
Related job: https://github.com/upbound/provider-gcp/actions/runs/6348941231/job/17246371408

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

