### PR TITLE
Fix the path from/to which the Go mod cache is populated in e2e test runs

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -31,9 +31,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
-      - name: Find the Go Build Cache
+      - name: Find Go Caches
         id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+          echo "modcache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
@@ -45,7 +47,7 @@ jobs:
       - name: Cache Go Dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
-          path: .work/pkg
+          path: ${{ steps.go.outputs.modcache }}
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 

--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -126,10 +126,12 @@ jobs:
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
 
-      - name: Find the Go Build Cache
+      - name: Find Go Caches
         if: ${{ inputs.package-type  == 'provider' }}
         id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+          echo "modcache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         if: ${{ inputs.package-type  == 'provider' }}
@@ -139,11 +141,11 @@ jobs:
           key: ${{ runner.os }}-build-uptest-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-uptest-
 
-      - name: Cache Go Dependencies
+      - name: Cache the Go Dependencies
         if: ${{ inputs.package-type  == 'provider' }}
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
-          path: .work/pkg
+          path: ${{ steps.go.outputs.modcache }}
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -30,9 +30,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go Build Cache
+      - name: Find Go Caches
         id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+          echo "modcache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
@@ -44,7 +46,7 @@ jobs:
       - name: Cache Go Dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
-          path: .work/pkg
+          path: ${{ steps.go.outputs.modcache }}
           key: ${{ runner.os }}-updoc-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-updoc-pkg-
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Currently, we are using `.work/pkg` as the path from/to which the Go mod cache is populated in the official providers' e2e tests. This path does not exist and thus the go mods need to be downloaded again during the builds for the e2e tests:
<img width="954" alt="image" src="https://github.com/upbound/uptest/assets/9376684/297b97dc-f3d3-4cbe-80e0-da3ff10b8006">

<img width="978" alt="image" src="https://github.com/upbound/uptest/assets/9376684/e5965877-e510-41ca-bd33-43a93601e1d7">
 
This PR proposes to fix that path using the output of the `go.mod.cachedir` make target. I've also verified that the OP repos `upbound/provider-{aws,azure/ad,gcp,terraform}` all contain that make target.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against `upbound/provider-aws`:
<img width="1407" alt="image" src="https://github.com/upbound/uptest/assets/9376684/97a8984d-7aea-480d-ac4c-bcaa91ac6251">
