### PR TITLE
Use 1.20 for the default Go versions in the official provider reusable workflows

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -9,7 +9,7 @@ on:
         type: string
       go-version:
         description: 'Go version to use if building needs to be done'
-        default: '1.19'
+        default: '1.20'
         required: false
         type: string
     secrets:

--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -10,7 +10,7 @@ on:
         type: string
       go-version:
         description: 'Go version to use if building needs to be done'
-        default: '1.19'
+        default: '1.20'
         required: false
         type: string
       package-type:

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.54.1'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.54.1'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
   UP_VERSION: 'v0.17.0'

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
   UPTEST_VERSION: "83bd901"
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We would like to switch from 1.19 to 1.20 as the default Go version in the official provider repositories. This PR changes the default Go version specified in the reusable workflows that the OP repositories employ.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested manually against the `upbound/provider-aws` repo.