### PR TITLE
Fix resource import test's new and old ID assertion

### DIFF
--- a/internal/templates/02-assert.yaml.tmpl
+++ b/internal/templates/02-assert.yaml.tmpl
@@ -14,6 +14,6 @@ commands:
 {{- end }}
 {{- end }}
 {{- if not $resource.Namespace }}
-- script: new_id=$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider.id}') && old_id=$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.metadata.annotations.uptest-old-id}') && [ "$new_id" == "$old_id" ]
+- script: new_id="$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider.id}')" && old_id="$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.metadata.annotations.uptest-old-id}')" && [ "$new_id" = "$old_id" ]
 {{- end }}
 {{- end }}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -114,7 +114,7 @@ timeout: 10
 commands:
 - script: echo "Dump MR manifests for the import assertion step:"; ${KUBECTL} get managed -o yaml
 - command: ${KUBECTL} wait s3.aws.upbound.io/example-bucket --for=condition=Test --timeout 10s
-- script: new_id=$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.status.atProvider.id}') && old_id=$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.metadata.annotations.uptest-old-id}') && [ "$new_id" == "$old_id" ]
+- script: new_id="$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.status.atProvider.id}')" && old_id="$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.metadata.annotations.uptest-old-id}')" && [ "$new_id" = "$old_id" ]
 `,
 					"02-import.yaml": `# This file belongs to the resource import step.
 apiVersion: kuttl.dev/v1beta1
@@ -221,7 +221,7 @@ timeout: 10
 commands:
 - script: echo "Dump MR manifests for the import assertion step:"; ${KUBECTL} get managed -o yaml
 - command: ${KUBECTL} wait s3.aws.upbound.io/example-bucket --for=condition=Test --timeout 10s
-- script: new_id=$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.status.atProvider.id}') && old_id=$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.metadata.annotations.uptest-old-id}') && [ "$new_id" == "$old_id" ]
+- script: new_id="$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.status.atProvider.id}')" && old_id="$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.metadata.annotations.uptest-old-id}')" && [ "$new_id" = "$old_id" ]
 `,
 					"02-import.yaml": `# This file belongs to the resource import step.
 apiVersion: kuttl.dev/v1beta1


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In https://github.com/upbound/provider-aws/actions/runs/6460833777/job/17539319778, we have encountered the following error in the resource import tests:
```
...
logger.go:42: 19:43:15 | case/2-import | running command: [sh -c new_id=$(${KUBECTL} get streamconsumer.kinesis.aws.upbound.io/example -o=jsonpath='{.status.atProvider.id}') && old_id=$(${KUBECTL} get streamconsumer.kinesis.aws.upbound.io/example -o=jsonpath='{.metadata.annotations.uptest-old-id}') && [ "$new_id" == "$old_id" ]]
logger.go:42: 19:43:15 | case/2-import | sh: 1: [: arn:aws:kinesis:us-west-1:153891904029:stream/example/consumer/example-consumer:1696879709: unexpected operator
logger.go:42: 19:43:15 | case/2-import | command failure, skipping 2 additional commands
...
```

We need to use the `=` operator instead of the `==` operator with `sh`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested manually with `sh`.