### PR TITLE
Parameterize the Go version used in the provider reusable workflows

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: boolean
         default: true
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.20'
+        required: false
+        type: string
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -15,7 +20,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.54.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
@@ -78,7 +82,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find the Go Build Cache
         id: go_cache
@@ -109,6 +113,7 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           version: ${{ env.GOLANGCI_VERSION }}
+          args: --timeout=30m
 
   check-diff:
     runs-on: ubuntu-22.04
@@ -124,7 +129,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
@@ -193,7 +198,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find the Go Build Cache
         id: go_cache
@@ -244,7 +249,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find the Go Build Cache
         id: go_cache
@@ -308,7 +313,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find the Go Build Cache
         id: go_cache

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -33,6 +33,11 @@ on:
         default: ''
         required: false
         type: string
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.20'
+        required: false
+        type: string
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -41,7 +46,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.54.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
   UP_VERSION: 'v0.17.0'
@@ -100,7 +104,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find the Go Build Cache
         id: go_cache

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -8,12 +8,16 @@ on:
         default: 'monolith'
         required: false
         type: string
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.20'
+        required: false
+        type: string
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA:
         required: true
 
 env:
-  GO_VERSION: "1.20"
   UPTEST_VERSION: "83bd901"
 
 jobs:
@@ -28,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Find Go Caches
         id: go


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds new parameters named `go-version` with the default value of `1.20` in the provider reusable workflows so that a provider repository can override the Go version to be used in the CI jobs.

It also adds `--timeout=30m` to golangci-lint runs in the provider CI jobs.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
