### PR TITLE
Use ubuntu-20.04 machine type for provider-ci/lint job

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           make schema-version-diff
   lint:
-    runs-on: [e2-standard-8, linux]
+    runs-on: ubuntu-20.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 


### PR DESCRIPTION
### Description of your changes

Use ubuntu-20.04 machine type for provider-ci/lint job.

We observed some issues in the lint job on the provider-aws repo. In this [issue](https://github.com/actions/runner-images/discussions/7188), the users also report a similar problem, and they suggest downgrading the OS version to ubuntu-20.04.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
