### PR TITLE
Use e2-standard-8-20.04 machine type for CI/lint job

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           make schema-version-diff
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: e2-standard-8-20.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 


### PR DESCRIPTION
### Description of your changes

Use e2-standard-8-20.04 machine type for CI/lint job

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
