### PR TITLE
Use Ubuntu-Jumbo-Runner machine for provider-ci/lint job

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           make schema-version-diff
   lint:
-    runs-on: e2-standard-8-20.04
+    runs-on: Ubuntu-Jumbo-Runner
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 


### PR DESCRIPTION
### Description of your changes

Use Ubuntu-Jumbo-Runner machine for lint job to handle lint job failures

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Will be tested in aws provider after merged.
