### PR TITLE
Add disable options for Update and Import steps

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,9 @@ const (
 	// AnnotationKeyExampleID is id of example that populated from example
 	// manifest. This information will be used for determining the root resource
 	AnnotationKeyExampleID = "meta.upbound.io/example-id"
+	// AnnotationKeyDisableImport defines that determines whether the Import
+	// step of the resource to be tested will be executed or not.
+	AnnotationKeyDisableImport = "uptest.upbound.io/disable-import"
 )
 
 // AutomatedTest represents an automated test of resource example
@@ -72,6 +75,8 @@ type TestCase struct {
 	Timeout            int
 	SetupScriptPath    string
 	TeardownScriptPath string
+	SkipUpdate         bool
+	SkipImport         bool
 }
 
 // Resource represents a Kubernetes object to be tested and asserted

--- a/internal/runner.go
+++ b/internal/runner.go
@@ -15,6 +15,9 @@
 package internal
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/uptest/internal/config"
@@ -22,6 +25,12 @@ import (
 
 // RunTest runs the specified automated test
 func RunTest(o *config.AutomatedTest) error {
+	defer func() {
+		if err := os.RemoveAll(o.Directory); err != nil {
+			fmt.Println(fmt.Sprint(err, "cannot clean the test directory"))
+		}
+	}()
+
 	// Read examples and inject data source values to manifests
 	manifests, err := newPreparer(o.ManifestPaths, withDataSource(o.DataSourcePath), withTestDirectory(o.Directory)).prepareManifests()
 	if err != nil {

--- a/internal/templates/01-assert.yaml.tmpl
+++ b/internal/templates/01-assert.yaml.tmpl
@@ -5,9 +5,6 @@ timeout: {{ .TestCase.Timeout }}
 commands:
 - script: echo "Dump MR manifests for the update assertion step:"; ${KUBECTL} get managed -o yaml
 {{- range $resource := .Resources }}
-{{- if eq $resource.UpdateParameter "" -}}
-  {{continue}}
-{{- end -}}
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}

--- a/internal/templates/01-update.yaml.tmpl
+++ b/internal/templates/01-update.yaml.tmpl
@@ -3,9 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 {{- range $resource := .Resources }}
-{{- if eq $resource.UpdateParameter "" -}}
-  {{continue}}
-{{- end -}}
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -49,6 +49,14 @@ func Render(tc *config.TestCase, resources []config.Resource, skipDelete bool) (
 
 	res := make(map[string]string, len(fileTemplates))
 	for name, tmpl := range fileTemplates {
+		// Skip templates with names starting with "01-" if skipUpdate is true
+		if tc.SkipUpdate && strings.HasPrefix(name, "01-") {
+			continue
+		}
+		// Skip templates with names starting with "02-" if skipImport is true
+		if tc.SkipImport && strings.HasPrefix(name, "02-") {
+			continue
+		}
 		// Skip templates with names starting with "03-" if skipDelete is true
 		if skipDelete && strings.HasPrefix(name, "03-") {
 			continue

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -138,10 +138,16 @@ func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 				return nil, nil, errors.Wrapf(err, "cannot unmarshal JSON object: %s", updateParameter)
 			}
 			example.UpdateAssertKey, example.UpdateAssertValue = convertToJSONPath(data, "")
+		} else {
+			tc.SkipUpdate = true
 		}
 
 		if exampleID, ok := annotations[config.AnnotationKeyExampleID]; ok {
 			if exampleID == strings.ToLower(fmt.Sprintf("%s/%s/%s", strings.Split(groupVersionKind.Group, ".")[0], groupVersionKind.Version, groupVersionKind.Kind)) {
+				disableImport, ok := annotations[config.AnnotationKeyDisableImport]
+				if ok && disableImport == "true" {
+					tc.SkipImport = true
+				}
 				example.Root = true
 			}
 		}


### PR DESCRIPTION
This PR adds disable options for Update and Import steps and adds defer statment to remove all test directory before completing the cases.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Locally tested
