### PR TITLE
Skip import id-check step on non-root resources

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,9 @@ const (
 	// AnnotationKeyExampleID is id of example that populated from example
 	// manifest. This information will be used for determining the root resource
 	AnnotationKeyExampleID = "meta.upbound.io/example-id"
+	// AnnotationKeyDisableImport defines that determines whether the Import
+	// step of the resource to be tested will be executed or not.
+	AnnotationKeyDisableImport = "uptest.upbound.io/disable-import"
 )
 
 // AutomatedTest represents an automated test of resource example
@@ -72,6 +75,8 @@ type TestCase struct {
 	Timeout            int
 	SetupScriptPath    string
 	TeardownScriptPath string
+	SkipUpdate         bool
+	SkipImport         bool
 }
 
 // Resource represents a Kubernetes object to be tested and asserted

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ const (
 	// AnnotationKeyExampleID is id of example that populated from example
 	// manifest. This information will be used for determining the root resource
 	AnnotationKeyExampleID = "meta.upbound.io/example-id"
-	// AnnotationKeyDisableImport defines that determines whether the Import
+	// AnnotationKeyDisableImport determines whether the Import
 	// step of the resource to be tested will be executed or not.
 	AnnotationKeyDisableImport = "uptest.upbound.io/disable-import"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,5 +98,7 @@ type Resource struct {
 	UpdateAssertKey   string
 	UpdateAssertValue string
 
+	SkipImport bool
+
 	Root bool
 }

--- a/internal/runner.go
+++ b/internal/runner.go
@@ -15,6 +15,9 @@
 package internal
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/uptest/internal/config"
@@ -22,6 +25,12 @@ import (
 
 // RunTest runs the specified automated test
 func RunTest(o *config.AutomatedTest) error {
+	defer func() {
+		if err := os.RemoveAll(o.Directory); err != nil {
+			fmt.Println(fmt.Sprint(err, "cannot clean the test directory"))
+		}
+	}()
+
 	// Read examples and inject data source values to manifests
 	manifests, err := newPreparer(o.ManifestPaths, withDataSource(o.DataSourcePath), withTestDirectory(o.Directory)).prepareManifests()
 	if err != nil {

--- a/internal/templates/01-assert.yaml.tmpl
+++ b/internal/templates/01-assert.yaml.tmpl
@@ -5,9 +5,6 @@ timeout: {{ .TestCase.Timeout }}
 commands:
 - script: echo "Dump MR manifests for the update assertion step:"; ${KUBECTL} get managed -o yaml
 {{- range $resource := .Resources }}
-{{- if eq $resource.UpdateParameter "" -}}
-  {{continue}}
-{{- end -}}
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}

--- a/internal/templates/01-update.yaml.tmpl
+++ b/internal/templates/01-update.yaml.tmpl
@@ -3,9 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 {{- range $resource := .Resources }}
-{{- if eq $resource.UpdateParameter "" -}}
-  {{continue}}
-{{- end -}}
 {{- if eq $resource.KindGroup "secret." -}}
   {{continue}}
 {{- end -}}

--- a/internal/templates/02-assert.yaml.tmpl
+++ b/internal/templates/02-assert.yaml.tmpl
@@ -13,7 +13,7 @@ commands:
 - command: ${KUBECTL} wait {{ $resource.KindGroup }}/{{ $resource.Name }} --for=condition={{ $condition }} --timeout 10s
 {{- end }}
 {{- end }}
-{{- if not $resource.Namespace }}
+{{- if not (or $resource.Namespace $resource.SkipImport) }}
 - script: new_id="$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.status.atProvider.id}')" && old_id="$(${KUBECTL} get {{ $resource.KindGroup }}/{{ $resource.Name }} -o=jsonpath='{.metadata.annotations.uptest-old-id}')" && [ "$new_id" = "$old_id" ]
 {{- end }}
 {{- end }}

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -49,6 +49,14 @@ func Render(tc *config.TestCase, resources []config.Resource, skipDelete bool) (
 
 	res := make(map[string]string, len(fileTemplates))
 	for name, tmpl := range fileTemplates {
+		// Skip templates with names starting with "01-" if skipUpdate is true
+		if tc.SkipUpdate && strings.HasPrefix(name, "01-") {
+			continue
+		}
+		// Skip templates with names starting with "02-" if skipImport is true
+		if tc.SkipImport && strings.HasPrefix(name, "02-") {
+			continue
+		}
 		// Skip templates with names starting with "03-" if skipDelete is true
 		if skipDelete && strings.HasPrefix(name, "03-") {
 			continue

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -427,12 +427,12 @@ commands:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: ${KUBECTL} scale deployment crossplane -n upbound-system --replicas=0
-- script: ${KUBECTL} -n upbound-system get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n upbound-system scale deploy --replicas=0
+- command: ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=0
+- script: ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=0
 - command: ${KUBECTL} --subresource=status patch s3.aws.upbound.io/example-bucket --type=merge -p '{"status":{"conditions":[]}}'
 - script: ${KUBECTL} annotate s3.aws.upbound.io/example-bucket uptest-old-id=$(${KUBECTL} get s3.aws.upbound.io/example-bucket -o=jsonpath='{.status.atProvider.id}') --overwrite
-- command: ${KUBECTL} scale deployment crossplane -n upbound-system --replicas=1
-- script: ${KUBECTL} -n upbound-system get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n upbound-system scale deploy --replicas=1
+- command: ${KUBECTL} scale deployment crossplane -n ${CROSSPLANE_NAMESPACE} --replicas=1
+- script: ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} get deploy --no-headers -o custom-columns=":metadata.name" | grep "provider-" | xargs ${KUBECTL} -n ${CROSSPLANE_NAMESPACE} scale deploy --replicas=1
 `,
 				},
 			},

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -138,10 +138,16 @@ func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 				return nil, nil, errors.Wrapf(err, "cannot unmarshal JSON object: %s", updateParameter)
 			}
 			example.UpdateAssertKey, example.UpdateAssertValue = convertToJSONPath(data, "")
+		} else {
+			tc.SkipUpdate = true
 		}
 
 		if exampleID, ok := annotations[config.AnnotationKeyExampleID]; ok {
 			if exampleID == strings.ToLower(fmt.Sprintf("%s/%s/%s", strings.Split(groupVersionKind.Group, ".")[0], groupVersionKind.Version, groupVersionKind.Kind)) {
+				disableImport, ok := annotations[config.AnnotationKeyDisableImport]
+				if ok && disableImport == "true" {
+					tc.SkipImport = true
+				}
 				example.Root = true
 			}
 		}

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -141,14 +141,18 @@ func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 		} else {
 			tc.SkipUpdate = true
 		}
+		disableImport, ok := annotations[config.AnnotationKeyDisableImport]
+		if ok && disableImport == "true" {
+			example.SkipImport = true
+		}
 
 		if exampleID, ok := annotations[config.AnnotationKeyExampleID]; ok {
 			if exampleID == strings.ToLower(fmt.Sprintf("%s/%s/%s", strings.Split(groupVersionKind.Group, ".")[0], groupVersionKind.Version, groupVersionKind.Kind)) {
-				disableImport, ok := annotations[config.AnnotationKeyDisableImport]
-				if ok && disableImport == "true" {
+				if disableImport == "true" {
 					tc.SkipImport = true
 				}
 				example.Root = true
+
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
I expanded on @sergenyalcin's work in #170 and added the ability to place the `uptest.upbound.io/disable-import: "true"` on a non-root resource, which makes the import step still run, but omit that resource from the check that the new resources have the same id.

This allows the use of examples containing e.g. Object.s3.aws.upbound.io resources, for which the terraform provider returns a differently-formatted id depending on whether the resource is created or observed. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I used this to locally test https://github.com/upbound/provider-aws/pull/1039 successfully.

I added a new unit test, and it passes.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
