### PR TITLE
Add support for optionally only clean-up resources that uptest created

### DIFF
--- a/cmd/uptest/main.go
+++ b/cmd/uptest/main.go
@@ -54,8 +54,9 @@ var (
 	defaultConditions = e2e.Flag("default-conditions", "Comma separated list of default conditions to wait for a successful test.\n"+
 		"Conditions could be overridden per resource using \"uptest.upbound.io/conditions\" annotation.").Default("Ready").String()
 
-	skipDelete = e2e.Flag("skip-delete", "Skip the delete step of the test.").Default("false").Bool()
-	testDir    = e2e.Flag("test-directory", "Directory where kuttl test case will be generated and executed.").Envar("UPTEST_TEST_DIR").Default(filepath.Join(os.TempDir(), "uptest-e2e")).String()
+	skipDelete               = e2e.Flag("skip-delete", "Skip the delete step of the test.").Default("false").Bool()
+	testDir                  = e2e.Flag("test-directory", "Directory where kuttl test case will be generated and executed.").Envar("UPTEST_TEST_DIR").Default(filepath.Join(os.TempDir(), "uptest-e2e")).String()
+	onlyCleanUptestResources = e2e.Flag("only-clean-uptest-resources", "While deletion step, only clean resources that were created by uptest").Default("false").Bool()
 )
 
 var (
@@ -115,14 +116,15 @@ func e2eTests() {
 		}
 	}
 	o := &config.AutomatedTest{
-		ManifestPaths:      examplePaths,
-		DataSourcePath:     *dataSourcePath,
-		SetupScriptPath:    setupPath,
-		TeardownScriptPath: teardownPath,
-		DefaultConditions:  strings.Split(*defaultConditions, ","),
-		DefaultTimeout:     *defaultTimeout,
-		Directory:          *testDir,
-		SkipDelete:         *skipDelete,
+		ManifestPaths:            examplePaths,
+		DataSourcePath:           *dataSourcePath,
+		SetupScriptPath:          setupPath,
+		TeardownScriptPath:       teardownPath,
+		DefaultConditions:        strings.Split(*defaultConditions, ","),
+		DefaultTimeout:           *defaultTimeout,
+		Directory:                *testDir,
+		SkipDelete:               *skipDelete,
+		OnlyCleanUptestResources: *onlyCleanUptestResources,
 	}
 
 	kingpin.FatalIfError(internal.RunTest(o), "cannot run e2e tests successfully")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,8 @@ type AutomatedTest struct {
 	DefaultConditions []string
 
 	SkipDelete bool
+
+	OnlyCleanUptestResources bool
 }
 
 // Manifest represents a resource loaded from an example resource manifest file.
@@ -72,6 +74,8 @@ type TestCase struct {
 	Timeout            int
 	SetupScriptPath    string
 	TeardownScriptPath string
+
+	OnlyCleanUptestResources bool
 }
 
 // Resource represents a Kubernetes object to be tested and asserted

--- a/internal/templates/03-assert.yaml.tmpl
+++ b/internal/templates/03-assert.yaml.tmpl
@@ -15,7 +15,9 @@ commands:
 - command: ${KUBECTL} wait {{ $resource.KindGroup }}/{{ $resource.Name }} --for=delete --timeout 10s
 {{- end }}
 {{- end }}
+{{- if not .TestCase.OnlyCleanUptestResources }}
 - command: ${KUBECTL} wait managed --all --for=delete --timeout 10s
+{{- end }}
 {{- if .TestCase.TeardownScriptPath }}
 - command: {{ .TestCase.TeardownScriptPath }}
 {{- end }}

--- a/internal/tester.go
+++ b/internal/tester.go
@@ -63,9 +63,10 @@ func (t *tester) executeTests() error {
 
 func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { //nolint:gocyclo // TODO: can we break this?
 	tc := &config.TestCase{
-		Timeout:            t.options.DefaultTimeout,
-		SetupScriptPath:    t.options.SetupScriptPath,
-		TeardownScriptPath: t.options.TeardownScriptPath,
+		Timeout:                  t.options.DefaultTimeout,
+		SetupScriptPath:          t.options.SetupScriptPath,
+		TeardownScriptPath:       t.options.TeardownScriptPath,
+		OnlyCleanUptestResources: t.options.OnlyCleanUptestResources,
 	}
 	examples := make([]config.Resource, 0, len(t.manifests))
 


### PR DESCRIPTION
### Description of your changes

This PR adds support for optionally only clean-up resources that uptest created.

Fixes #172 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.
