### PR TITLE
Clean case directory during preparation step

### DIFF
--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -77,6 +77,7 @@ type preparer struct {
 	testDirectory  string
 }
 
+//nolint:gocyclo // This function is not complex, gocyclo threshold was reached due to the error handling.
 func (p *preparer) prepareManifests() ([]config.Manifest, error) {
 	caseDirectory := filepath.Join(p.testDirectory, caseDirectory)
 	if err := os.RemoveAll(caseDirectory); err != nil {

--- a/internal/prepare.go
+++ b/internal/prepare.go
@@ -79,6 +79,9 @@ type preparer struct {
 
 func (p *preparer) prepareManifests() ([]config.Manifest, error) {
 	caseDirectory := filepath.Join(p.testDirectory, caseDirectory)
+	if err := os.RemoveAll(caseDirectory); err != nil {
+		return nil, errors.Wrapf(err, "cannot clean directory %s", caseDirectory)
+	}
 	if err := os.MkdirAll(caseDirectory, os.ModePerm); err != nil {
 		return nil, errors.Wrapf(err, "cannot create directory %s", caseDirectory)
 	}


### PR DESCRIPTION

<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Cleaning directory is crutial to avoid unexpected uptest behavior when the cases are changing between uptest run
* The cases contents can change during the uptest version upgrade and when we use `--skip-delete` option
* Without this change the uptest behavior is confusing the user, e.g. the `--skip-delete` option does not effectively work after the standard run because `03-delete.yaml` case is not getting removed from the case directory
* Fixes #159 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

updating local cache with test build version in sample configuration of https://github.com/upbound/configuration-aws-eks-karpenter/

running `make e2e`

then running `make e2e SKIP_DELETE=--skip-delete`

Observe that `/var/folders/sx/0tlfb9ys20bbqnszv3lw12m40000gn/T/uptest-e2e/case` is getting properly cleaned now, and `03-delete.yaml` is not there anymore 
