### PR TITLE
Parameterize the golangci-lint version for the provider repositories

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -12,6 +12,11 @@ on:
         default: '1.20'
         required: false
         type: string
+      golangci-version:
+        description: 'The version string to be used with the golangci-lint action'
+        default: 'v1.55.2'
+        required: false
+        type: string
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -20,7 +25,6 @@ on:
 
 env:
   # Common versions
-  GOLANGCI_VERSION: 'v1.54.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
@@ -112,7 +116,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
-          version: ${{ env.GOLANGCI_VERSION }}
+          version: ${{ inputs.golangci-version }}
           args: --timeout=30m
 
   check-diff:


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
From time to time, we need to bump the golangci-lint version used with a specific official provider. In that case, we would like to be able to do so:
- Without the need for a change in the uptest repo where the common CI definitions reside
- Without bumping this dependency across all the provider repos

This PR parameterizes the golanci-lint version used in the provider build pipelines. It also bumps the default version used for that action to `v1.55.2`, which is necessary for https://github.com/upbound/provider-aws/pull/1075.


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
It's a little bit inconvenient to test these PRs as the providers consume these reusable workflows from the main branch of uptest due to security constraints on Github actions regarding the repo secrets. There are ways to test such PRs before merging them to the main branch but for relatively simple PRs like this one, we generally first merge them and test them from the main branch of `uptest` in the official provider repositories. We may need to adopt a new strategy if these reusable workflows are used in other repositories as well.