### PR TITLE
Fix skip update mechanism

### DIFF
--- a/internal/tester.go
+++ b/internal/tester.go
@@ -139,8 +139,6 @@ func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 				return nil, nil, errors.Wrapf(err, "cannot unmarshal JSON object: %s", updateParameter)
 			}
 			example.UpdateAssertKey, example.UpdateAssertValue = convertToJSONPath(data, "")
-		} else {
-			tc.SkipUpdate = true
 		}
 		disableImport, ok := annotations[config.AnnotationKeyDisableImport]
 		if ok && disableImport == "true" {
@@ -152,8 +150,10 @@ func (t *tester) prepareConfig() (*config.TestCase, []config.Resource, error) { 
 				if disableImport == "true" {
 					tc.SkipImport = true
 				}
+				if updateParameter == "" {
+					tc.SkipUpdate = true
+				}
 				example.Root = true
-
 			}
 		}
 


### PR DESCRIPTION
### Description of your changes

This PR fixes the skipping update mechanism. In the current behavior, the uptest skips the update test if at least one resource does not have an update-parameter annotation in the test manifest. 

With this fix, we will skip if the Root does not have the update-parameter annotation. Just to remind you, we are only doing update tests for Root resources. Please see: https://github.com/upbound/uptest/blob/ac36a0c985cc93e8e5dc445257e3f2122086bb9b/internal/templates/01-update.yaml.tmpl#L10

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally
