### PR TITLE
Disable the golangci-lint-action's own Go mod & Go build caches

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -118,6 +118,12 @@ jobs:
         with:
           version: ${{ inputs.golangci-version }}
           args: --timeout=30m
+          # we manage the mod cache with the same key across different jobs.
+          # no need for the lint action to manage its own Go mod cache.
+          skip-pkg-cache: true
+          # we manage the build cache with the same key across different jobs.
+          # no need for the lint action to manage its own Go build cache.
+          skip-build-cache: true
 
   check-diff:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We already manage [Go mod & build caches](https://github.com/upbound/uptest/blob/ac36a0c985cc93e8e5dc445257e3f2122086bb9b/.github/workflows/provider-ci.yml#L91) for the CI jobs of the official provider repositories to speed up the build times. The [golangci-lint action](https://github.com/golangci/golangci-lint-action) that we use to run the linter can itself maintain the Go build and mod caches, however, with a different cache key than we use, with the syntax explained [here](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#caching-internals).

This PR proposes to disable that action's own Go build and mod caches and use the caches we explicitly maintain, the caches with the keys `Linux-{build, pkg}-lint-`. This should also prevent the occasional tar errors we observe for these cache files.

An alternative would just be not populating the build and mod caches explicitly from the `Linux-{build, pkg}-lint-` keys and letting the action manage its own cache. I did not choose this way because it's less efficient than building a single cache with (almost) the same contents (please see the note below).

Note: The action caches the whole `pkg` folder instead of the `pkg/mod` folder as the caches we explicitly maintain do. The action's cache also has an expiration date, i.e., even if the contents of the `go.mod` file does not change, the cache will expire after a certain period of time (one week). From a practical point of view, the explicitly maintained cache should also be fine though.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually tested in the main branch of a fork repo of `upbound/provider-aws` and `upbound/provider-azuread`.