### PR TITLE
Run the jlumbroso/free-disk-space action in CI jobs

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -111,6 +111,16 @@ jobs:
     needs: get-example-list
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -293,6 +293,16 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Experiments logged in https://github.com/upbound/provider-aws/pull/1180 reveal that the `jlumbroso/free-disk-space` action helps with the failing `e2e` (`uptest`) CI workflows & `publish-artifacts` CI jobs. The `uptest` runs have failed on the standard (`ubuntu-22.04`) runners. I've performed experiments with two example manifests on standard runners:
- A relatively heavyweight `uptest` for the `Firewall.networkfirewall` example manifest was run [here](https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085139654), with 4 providers installed: The AWS provider family config package and 3 resource providers: `provider-aws-{networkfirewall, ec2, s3}`, with `ec2` being the largest (in terms of CRDs installed) AWS resource provider. This `uptest` run has failed consistently due to insufficient disk space while installing the `s3` resource provider. The other 3 provider packages were successfully installed:
<img width="1028" alt="image" src="https://github.com/upbound/provider-aws/assets/9376684/0bcb3d09-6c84-4aec-b359-168ef6fb33fe">

- `uptest` runs for the `Cluster.eks` example manifest also failed consistently with a disk space error [here](https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085346668/job/22092693751):
<img width="1001" alt="image" src="https://github.com/upbound/provider-aws/assets/9376684/794706b5-5507-482b-b41f-69269fac5484">

<hr>

With the `jlumbroso/free-disk-space` action run as part of the `e2e` CI workflow, things have consistently improved. Here are examples from successful runs:
- `Firewall.networkfirewall` -> https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085639241/job/22093639643
- `Cluster.eks` -> https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085642042/job/22093648022

This PR introduces the `jlumbroso/free-disk-space` action to clean up some disk space on the workflow runner before `uptest` is run and before `make build.all` is invoked (during the `publish-artifacts` job.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Following jobs on standard runners (on top of the `standard-runners` branch):
- `Firewall.networkfirewall` -> https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085639241/job/22093639643
- `Cluster.eks` -> https://github.com/ulucinar/upbound-provider-aws/actions/runs/8085642042/job/22093648022
