### PR TITLE
Add a condition disk clean-up step to reclaim some disk space in pr-comment-trigger & provider-ci reusable workflows

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -17,6 +17,11 @@ on:
         default: 'provider'
         required: false
         type: string
+      cleanup-disk:
+        description: "If set to true, an initial step will be run to reclaim some extra disk space for the uptest job in this workflow"
+        required: false
+        type: boolean
+        default: false
       update-test-parameter:
         description: 'Input parameter to use during update step. If this field
         is empty, then the update step will be skipped.
@@ -113,6 +118,7 @@ jobs:
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
         with:
           android: true
           dotnet: true

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -12,6 +12,11 @@ on:
         default: '1.20'
         required: false
         type: string
+      cleanup-disk:
+        description: "If set to true, an initial step will be run to reclaim some extra disk space for the build/test jobs in this workflow"
+        required: false
+        type: boolean
+        default: false
       golangci-version:
         description: 'The version string to be used with the golangci-lint action'
         default: 'v1.55.2'
@@ -78,6 +83,17 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
@@ -131,6 +147,17 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
@@ -197,6 +224,17 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
@@ -248,6 +286,17 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
@@ -295,6 +344,7 @@ jobs:
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
         with:
           android: true
           dotnet: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We have failing CI workflows in the `release-0.47` branch of `upbound/provider-aws` with insufficient disk space. An example run is [here](https://github.com/upbound/provider-aws/actions/runs/8180011046/job/22367202437?pr=1195). We would like to give the `jlumbroso/free-disk-space` action a try in that branch to see whether it resolves these issues. Previously we had relied on manual running of the failing jobs for that branch. This action has already helped us for running `uptest` on the free hosted runners.

This PR also makes them conditional. An observation from @sergenyalcin after we introduced the `jlumbroso/free-disk-space` is that it takes around 7m on a larger hosted runner with more disk space. We don't need to run the disk cleanup action for those larger runners and thus a switch to control the enablement of the step will help. By default, we won't running the disk cleanup step and we will only enable it when needed.

In this PR, we don't implement a fine granular switch specific to each job which controls the disk cleanup step but rather a global switch for all the jobs defined in a workflow. Also we did not include the disk cleanup step for each and every job in a workflow. I don't think we currently need a granular control specific to each job atm. We can keep adding the clean-up step for the remaining jobs as needed.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
