### PR TITLE
Bump up version to v0.24.2 in the provider-publish-service-artifacts workflow

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -48,7 +48,7 @@ env:
   # Common versions
   GOLANGCI_VERSION: 'v1.54.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
-  UP_VERSION: 'v0.17.0'
+  UP_VERSION: 'v0.24.2'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
   # step 'if env.XXX' != ""', so we copy these to succinctly test whether


### PR DESCRIPTION
### Description of your changes

This PR bumps the up version to `v0.24.2` in provider-publish-service-artifacts workflow.

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
