### PR TITLE
Run "up login" with the UP_TOKEN environment and a PAT instead of "up login -u"

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Login to Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
         env:
-          UP_PASSWORD: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+          UP_TOKEN: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
         run: |
           curl -fsSLo /tmp/up --create-dirs 'https://cli.upbound.io/stable/${{ env.UP_VERSION }}/bin/linux_amd64/up' && \
           chmod +x /tmp/up && \
-          /tmp/up login -u ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+          /tmp/up login
 
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR switches to PAT credentials in the `publish-service-artifacts` workflow from user credentials for the `up login` command. The session token then authenticates the workflow against the Upbound registry to push the family provider packages.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The command and its environment have been tested on my local machine.