### PR TITLE
Add the "Cleanup Disk" step also for the publish-service-artifacts CI job

### DIFF
--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -38,6 +38,11 @@ on:
         default: '1.20'
         required: false
         type: string
+      cleanup-disk:
+        description: "If set to true, an initial step will be run to reclaim some extra disk space for the build/test jobs in this workflow"
+        required: false
+        type: boolean
+        default: false
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR:
         required: true
@@ -73,6 +78,17 @@ jobs:
     needs: index
     runs-on: [e2-standard-8, linux]
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
CI run for the `publish-service-artifacts` job [here](https://github.com/upbound/provider-aws/actions/runs/8249459854/job/22561895636) reveals that we may be able to benefit from disk cleaning also for this job:
<img width="893" alt="image" src="https://github.com/upbound/uptest/assets/9376684/2898a7f3-b5b6-411c-9992-b1d440404043">


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Will be tested once we consume it in provider-aws.