### PR TITLE
Fix the repo name calculation logic in the Updoc CI workflow

### DIFF
--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -69,13 +69,13 @@ jobs:
         run: |
           if [[ "${GITHUB_REF##*/}" == release-* ]]; then
             for s in $SUBPACKAGES; do
-              PROVIDER_PACKAGE_NAME="${{ env.PROVIDER_NAME }}-$s"
+              PROVIDER_PACKAGE_NAME="${PROVIDER_NAME/-upjet/}-$s"
               DOCS_DIR="./docs/family"
                 if [ $s == 'monolith' ]; then
-                  PROVIDER_PACKAGE_NAME="${{ env.PROVIDER_NAME }}"
+                  PROVIDER_PACKAGE_NAME="${PROVIDER_NAME/-upjet/}"
                   DOCS_DIR="./docs/monolith"
                 elif [ $s == 'config' ]; then
-                  PROVIDER_PACKAGE_NAME="provider-family-${GITHUB_REPOSITORY#*-}"
+                  PROVIDER_PACKAGE_NAME="provider-family-${GITHUB_REPOSITORY##*-}"
                   DOCS_DIR="./docs/family"
                 fi
                 echo "Publishing Docs for $PROVIDER_PACKAGE_NAME, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As we moved the official providers `upbound/provider-{aws, azure, azuread, gcp}` to their homes `crossplane-contrib/provider-upjet-{aws, azure, azuread, gcp}`, we will need to fix/change the provider repo name calculation in the reusable `Updoc` workflow so that we still compute the old repo names for these providers. This is required because although we have moved these providers to new repositories, the published package names are kept intact for backwards compatibility reasons.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested the changes proposed in this PR here: https://github.com/ulucinar/uptest/actions/runs/8283714517/job/22667549446

Please note that even if we pass `provider-aws` or `provider-upjet-aws`, the calculated package names are as expected, e.g., `provider-aws-ec2`.